### PR TITLE
Allow overriding of JsonApiDatastore's error handler in derived classes...

### DIFF
--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -143,7 +143,7 @@ export class JsonApiDatastore {
     }
 
     protected handleError(error: any) {
-        let errMsg = (error.message) ? error.message :
+        let errMsg: string = (error.message) ? error.message :
             error.status ? `${error.status} - ${error.statusText}` : 'Server error';
         console.error(errMsg);
         return Observable.throw(errMsg);

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Headers, RequestOptions } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
@@ -98,7 +99,7 @@ export class JsonApiDatastore {
         return model;
     }
 
-    private handleError(error: any) {
+    protected handleError(error: any) {
         let errMsg = (error.message) ? error.message :
             error.status ? `${error.status} - ${error.statusText}` : 'Server error';
         console.error(errMsg);


### PR DESCRIPTION
I find this usefull because I need to pass detailed errors from the api into my application. Therefore I  wrote a custom error handler in my Datastore service to override the default error handler.