### PR TITLE
README: add braces to Attribute() decorator

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -97,10 +97,10 @@ import { JsonApiModelConfig, JsonApiModel, Attribute, HasMany, BelongsTo } from 
 })
 export class Post extends JsonApiModel {
 
-	@Attribute
+	@Attribute()
     title: string;
 
-	@Attribute
+	@Attribute()
     content: string;
 
     @HasMany()
@@ -112,7 +112,7 @@ export class Post extends JsonApiModel {
 })
 export class Comment extends JsonApiModel {
 
-	@Attribute
+	@Attribute()
     title: string;
 
     @BelongsTo()
@@ -127,7 +127,7 @@ export class Comment extends JsonApiModel {
 })
 export class User extends JsonApiModel {
 
-	@Attribute
+	@Attribute()
     name: string;
     // ...
 }
@@ -210,7 +210,7 @@ Use `peekRecord()` to retrieve a record by its type and ID, without making a net
 let post = this.datastore.peekRecord(Post, '1');
 ```
 
-### Creating, Updating and Deleting 
+### Creating, Updating and Deleting
 
 #### Creating Records
 

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -143,7 +143,7 @@ export class JsonApiDatastore {
     }
 
     protected handleError(error: any) {
-        let errMsg = (error.message) ? error.message :
+        let errMsg: string = (error.message) ? error.message :
             error.status ? `${error.status} - ${error.statusText}` : 'Server error';
         console.error(errMsg);
         return Observable.throw(errMsg);

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Headers, RequestOptions } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
@@ -98,7 +99,7 @@ export class JsonApiDatastore {
         return model;
     }
 
-    private handleError(error: any) {
+    protected handleError(error: any) {
         let errMsg = (error.message) ? error.message :
             error.status ? `${error.status} - ${error.statusText}` : 'Server error';
         console.error(errMsg);


### PR DESCRIPTION
My compiler throw an error when using the Attribute decorator without braces. Small change but important for newbies ;)

P.S. Github includes already merged commits from the last pull request in the preview of this pull request. I hope github resolves this when I finally create the pull request ;)