### PR TITLE
Support for more general json:api documents (links, data, meta)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@angular/platform-browser-dynamic": "2.2.3",
     "@angular/platform-server": "2.2.3",
     "@types/jasmine": "2.5.38",
-    "@types/lodash": "^4.14.37",
+    "@types/lodash": "4.14.37",
     "@types/reflect-metadata": "0.0.4",
     "@types/selenium-webdriver": "^2.53.30",
     "codelyzer": "~2.0.0-beta.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,10 @@ export * from './decorators/json-api-model-config.decorator';
 export * from './decorators/json-api-datastore-config.decorator';
 
 export * from './models/json-api.model';
+export * from './models/document.model';
+export * from './models/links.model';
+export * from './models/link.model';
 
 export * from './providers';
 
 export * from './module';
-

--- a/src/models/document.model.ts
+++ b/src/models/document.model.ts
@@ -1,22 +1,22 @@
 import { LinksModel } from './links.model';
 
 export class DocumentModel<T> {
-    _links: LinksModel = new LinksModel;
-    _data: T;
+  _links: LinksModel = new LinksModel;
+  _data: T;
 
-    constructor(body: any) {
-        this._links.updateLinks(body.links);
-    }
+  constructor(body: any) {
+    this._links.updateLinks(body.links);
+  }
+  
+  public links(name: string = null) {
+    return this._links.links(name);
+  }
 
-    public links(name: string = null) {
-        return this._links.links(name);
-    }
+  public data(): T {
+    return this._data;
+  }
 
-    public data(): T {
-        return this._data;
-    }
-
-    public setData(data: any) {
-        this._data = data;
-    }
+  public setData(data: any) {
+    this._data = data;
+  }
 }

--- a/src/models/document.model.ts
+++ b/src/models/document.model.ts
@@ -1,0 +1,22 @@
+import { LinksModel } from './links.model';
+
+export class DocumentModel<T> {
+    _links: LinksModel = new LinksModel;
+    _data: T;
+
+    constructor(body: any) {
+        this._links.updateLinks(body.links);
+    }
+
+    public links(name: string = null) {
+        return this._links.links(name);
+    }
+
+    public data(): T {
+        return this._data;
+    }
+
+    public setData(data: any) {
+        this._data = data;
+    }
+}

--- a/src/models/document.model.ts
+++ b/src/models/document.model.ts
@@ -1,22 +1,22 @@
 import { LinksModel } from './links.model';
 
 export class DocumentModel<T> {
-  _links: LinksModel = new LinksModel;
-  _data: T;
+  private _links: LinksModel = new LinksModel;
+  private _data: T;
 
   constructor(body: any) {
     this._links.updateLinks(body.links);
   }
-  
-  public links(name: string = null) {
-    return this._links.links(name);
+
+  get links() {
+    return this._links;
   }
 
-  public data(): T {
+  get data(): T {
     return this._data;
   }
 
-  public setData(data: any) {
+  set data(data: T) {
     this._data = data;
   }
 }

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -3,35 +3,25 @@ import 'reflect-metadata';
 import { Headers } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';
-import { DocumentModel } from './document.model';
 import { LinksModel } from './links.model';
 import { LinkModel } from './link.model';
 
 export class JsonApiModel {
 
   id: string;
-  _links: LinksModel = new LinksModel;
-  _document: DocumentModel<JsonApiModel>;
+  private _links: LinksModel = new LinksModel;
   [key: string]: any;
 
-  constructor(private _datastore: JsonApiDatastore, data?: any, document: DocumentModel<JsonApiModel> = null) {
+  constructor(private _datastore: JsonApiDatastore, data?: any) {
     if (data) {
       this.id = data.id;
       _.extend(this, data.attributes);
     }
-
-    if(document) {
-      this._document = document;
-    }
     this._links.updateLinks(data.links);
   }
 
-  public document(): DocumentModel<JsonApiModel> {
-    return this._document;
-  }
-
-  public links(name: string = null) {
-    return this._links.links(name);
+  get links() {
+    return this._links;
   }
 
   syncRelationships(data: any, included: any, level: number): void {
@@ -151,7 +141,7 @@ export class JsonApiModel {
     if (peek) {
       return peek;
     }
-    let newObject: T = new modelType(this._datastore, data, null);
+    let newObject: T = new modelType(this._datastore, data);
     this._datastore.addToStore(newObject);
     return newObject;
   }

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Observable';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';
 import { LinksModel } from './links.model';
 import { LinkModel } from './link.model';
+import { DocumentModel } from '../models/document.model';
 
 export class JsonApiModel {
 
@@ -30,7 +31,7 @@ export class JsonApiModel {
     }
   }
 
-  save(params?: any, headers?: Headers): Observable<this> {
+  save(params?: any, headers?: Headers): Observable<DocumentModel<this>> {
     let attributesMetadata: any = Reflect.getMetadata('Attribute', this);
     return this._datastore.saveRecord(attributesMetadata, this, params, headers);
   }

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -3,17 +3,35 @@ import 'reflect-metadata';
 import { Headers } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';
+import { DocumentModel } from './document.model';
+import { LinksModel } from './links.model';
+import { LinkModel } from './link.model';
 
 export class JsonApiModel {
 
   id: string;
+  _links: LinksModel = new LinksModel;
+  _document: DocumentModel<JsonApiModel>;
   [key: string]: any;
 
-  constructor(private _datastore: JsonApiDatastore, data?: any) {
+  constructor(private _datastore: JsonApiDatastore, data?: any, document: DocumentModel<JsonApiModel> = null) {
     if (data) {
       this.id = data.id;
       _.extend(this, data.attributes);
     }
+
+    if(document) {
+      this._document = document;
+    }
+    this._links.updateLinks(data.links);
+  }
+
+  public document(): DocumentModel<JsonApiModel> {
+    return this._document;
+  }
+
+  public links(name: string = null) {
+    return this._links.links(name);
   }
 
   syncRelationships(data: any, included: any, level: number): void {
@@ -133,7 +151,7 @@ export class JsonApiModel {
     if (peek) {
       return peek;
     }
-    let newObject: T = new modelType(this._datastore, data);
+    let newObject: T = new modelType(this._datastore, data, null);
     this._datastore.addToStore(newObject);
     return newObject;
   }

--- a/src/models/link.model.ts
+++ b/src/models/link.model.ts
@@ -1,7 +1,7 @@
 export class LinkModel {
   private _name: string;
   private _href: string;
-  //TODO: add meta
+  // TODO: add meta
 
   constructor(name: string, link: any) {
     this._name = name;

--- a/src/models/link.model.ts
+++ b/src/models/link.model.ts
@@ -1,0 +1,21 @@
+export class LinkModel {
+    private _href: string;
+    private _name: string;
+    //TODO: add meta
+
+    constructor(name: string, link: any) {
+        this._name = name;
+    }
+
+    name() {
+        return this._name;
+    }
+
+    href() {
+        return this._href;
+    }
+
+/*    meta() {
+        return this._meta;
+    }*/
+}

--- a/src/models/link.model.ts
+++ b/src/models/link.model.ts
@@ -1,21 +1,21 @@
 export class LinkModel {
-    private _href: string;
-    private _name: string;
-    //TODO: add meta
+  private _href: string;
+  private _name: string;
+  //TODO: add meta
 
-    constructor(name: string, link: any) {
-        this._name = name;
-    }
+  constructor(name: string, link: any) {
+    this._name = name;
+  }
 
-    name() {
-        return this._name;
-    }
+  name() {
+    return this._name;
+  }
 
-    href() {
-        return this._href;
-    }
+  href() {
+    return this._href;
+  }
 
-/*    meta() {
-        return this._meta;
-    }*/
+  /*    meta() {
+  return this._meta;
+}*/
 }

--- a/src/models/link.model.ts
+++ b/src/models/link.model.ts
@@ -1,21 +1,18 @@
 export class LinkModel {
-  private _href: string;
   private _name: string;
+  private _href: string;
   //TODO: add meta
 
   constructor(name: string, link: any) {
     this._name = name;
+    this._href = link;
   }
 
-  name() {
+  get name(): string {
     return this._name;
   }
 
-  href() {
+  get href(): string {
     return this._href;
   }
-
-  /*    meta() {
-  return this._meta;
-}*/
 }

--- a/src/models/links.model.ts
+++ b/src/models/links.model.ts
@@ -14,11 +14,4 @@ export class LinksModel {
       this[name] = new LinkModel(name, links[name]);
     });
   }
-
-  public links(name: string = null) {
-    if(name) {
-      return this[name];
-    }
-    return this;
-  }
 }

--- a/src/models/links.model.ts
+++ b/src/models/links.model.ts
@@ -4,12 +4,12 @@ export class LinksModel {
   [key: string]: any;
 
   public updateLinks(links: any) {
-    //delete all properties of this object
+    // delete all properties of this object
     Object.keys(this || {}).forEach((name) => {
       delete this[name];
     });
 
-    //assign new properties based on whats inside of links
+    // assign new properties based on whats inside of links
     Object.keys(links || {}).forEach((name) => {
       this[name] = new LinkModel(name, links[name]);
     });

--- a/src/models/links.model.ts
+++ b/src/models/links.model.ts
@@ -1,25 +1,25 @@
 import { LinkModel } from './link.model';
 
 export class LinksModel {
-    [key: string]: any;
+  [key: string]: any;
 
-    public updateLinks(links: any) {
-        //delete all properties of this object
-        Object.keys(this || {}).forEach((name) => {
-            console.log(name);
-            delete this[name];
-        });
+  public updateLinks(links: any) {
+    //delete all properties of this object
+    Object.keys(this || {}).forEach((name) => {
+      console.log(name);
+      delete this[name];
+    });
 
-        //assign new properties based on whats inside of links
-        Object.keys(links || {}).forEach((name) => {
-            this[name] = new LinkModel(name, links[name]);
-        });
+    //assign new properties based on whats inside of links
+    Object.keys(links || {}).forEach((name) => {
+      this[name] = new LinkModel(name, links[name]);
+    });
+  }
+
+  public links(name: string = null) {
+    if(name) {
+      return this[name];
     }
-
-    public links(name: string = null) {
-        if(name) {
-            return this[name];
-        }
-        return this;
-    }
+    return this;
+  }
 }

--- a/src/models/links.model.ts
+++ b/src/models/links.model.ts
@@ -1,0 +1,25 @@
+import { LinkModel } from './link.model';
+
+export class LinksModel {
+    [key: string]: any;
+
+    public updateLinks(links: any) {
+        //delete all properties of this object
+        Object.keys(this || {}).forEach((name) => {
+            console.log(name);
+            delete this[name];
+        });
+
+        //assign new properties based on whats inside of links
+        Object.keys(links || {}).forEach((name) => {
+            this[name] = new LinkModel(name, links[name]);
+        });
+    }
+
+    public links(name: string = null) {
+        if(name) {
+            return this[name];
+        }
+        return this;
+    }
+}

--- a/src/models/links.model.ts
+++ b/src/models/links.model.ts
@@ -6,7 +6,6 @@ export class LinksModel {
   public updateLinks(links: any) {
     //delete all properties of this object
     Object.keys(this || {}).forEach((name) => {
-      console.log(name);
       delete this[name];
     });
 

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -46,7 +46,7 @@ export class JsonApiDatastore {
     return new modelType(this, {attributes: data});
   }
 
-  saveRecord<T extends JsonApiModel>(attributesMetadata: any, model?: T, params?: any, headers?: Headers): Observable<T> {
+  saveRecord<T extends JsonApiModel>(attributesMetadata: any, model?: T, params?: any, headers?: Headers): Observable<DocumentModel<T>> {
     let modelType = <ModelType<T>>model.constructor;
     let typeName: string = Reflect.getMetadata('JsonApiModelConfig', modelType).type;
     let options: RequestOptions = this.getOptions(headers);

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -13,8 +13,7 @@ import { DocumentModel } from '../models/document.model';
 export type ModelType<T extends JsonApiModel> = {
   new(
     datastore: JsonApiDatastore,
-    data: any,
-    document: DocumentModel<T>
+    data: any
   ): T;
 };
 
@@ -44,7 +43,7 @@ export class JsonApiDatastore {
   }
 
   createRecord<T extends JsonApiModel>(modelType: ModelType<T>, data?: any): T {
-    return new modelType(this, {attributes: data}, null);
+    return new modelType(this, {attributes: data});
   }
 
   saveRecord<T extends JsonApiModel>(attributesMetadata: any, model?: T, params?: any, headers?: Headers): Observable<T> {
@@ -130,12 +129,12 @@ export class JsonApiDatastore {
     return relationships;
   }
 
-  private extractQueryData<T extends JsonApiModel>(res: any, modelType: ModelType<T>): DocumentModel<T> {
+  private extractQueryData<T extends JsonApiModel>(res: any, modelType: ModelType<T>): DocumentModel<T[]> {
     let body: any = res.json();
     let models: T[] = [];
-    let document: DocumentModel<T> = new DocumentModel<T>(body);
+    let document: DocumentModel<T[]> = new DocumentModel<T[]>(body);
     body.data.forEach((data: any) => {
-      let model: T = new modelType(this, data, document);
+      let model: T = new modelType(this, data);
       this.addToStore(model);
       if (body.included) {
         model.syncRelationships(data, body.included, 0);
@@ -143,7 +142,7 @@ export class JsonApiDatastore {
       }
       models.push(model);
     });
-    document.setData(models);
+    document.data = models;
     return document;
   }
 
@@ -154,13 +153,13 @@ export class JsonApiDatastore {
       model.id = body.data.id;
       _.extend(model, body.data.attributes);
     }
-    model = model || new modelType(this, body.data, document);
+    model = model || new modelType(this, body.data);
     this.addToStore(model);
     if (body.included) {
       model.syncRelationships(body.data, body.included, 0);
       this.addToStore(model);
     }
-    document.setData(model);
+    document.data = model;
     return document;
   }
 


### PR DESCRIPTION
This is a proposal to implement #26. I followed the idea to use generics (mentioned in the issue) and did test:
- query
- findRecord
- save
- delete
  manually in my example project located at https://git.nordwest.freifunk.net/netmon-sc/web-client

If there are more changes needed, please let me know :)
