### PR TITLE
Support error objects from JSON API specification

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,6 +24,7 @@ A lightweight Angular 2 adapter for [JSON API](http://jsonapi.org/)
         - [Deleting Records](#deleting-records)
     - [Relationships](#relationships)
     - [Custom Headers](#custom-headers)
+    - [Error handling](#error-handling)
 - [TODO](#todo)
 - [Development](#development)
 - [License](#licence)
@@ -402,6 +403,27 @@ and in the `save()` method:
 post.save({}, new Headers({'Authorization': 'Bearer ' + accessToken})).subscribe();
 ```
 
+### Error handling
+
+Error handling is done in the `subscribe` method of the returned Observables. 
+If your server returns valid [JSON API Error Objects](http://jsonapi.org/format/#error-objects) you can access them in your onError method:
+
+```typescript
+import {ErrorResponse} from "angular2-jsonapi";
+
+...
+
+this.datastore.query(Post).subscribe(
+    (posts: Post[]) => console.log(posts),
+    (errorResponse) => {
+        if (errorResponse instanceof ErrorResponse) {
+              // do something with errorResponse
+              console.log(errorResponse.errors);
+        }
+    }
+);
+````
+It's also possible to handle errors for all requests by overriding `handleError(error: any): ErrorObservable` in the datastore. 
 
 ## TODO
 - [x] Deleting records

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './decorators/json-api-model-config.decorator';
 export * from './decorators/json-api-datastore-config.decorator';
 
 export * from './models/json-api.model';
+export * from './models/error-response.model';
 
 export * from './providers';
 

--- a/src/models/error-response.model.ts
+++ b/src/models/error-response.model.ts
@@ -1,4 +1,4 @@
-export interface Error {
+export interface JsonApiError {
     id?: string;
     links ?: Array<any>;
     status ?: string;
@@ -13,9 +13,9 @@ export interface Error {
 }
 
 export class ErrorResponse {
-    errors?: Error[] = [];
+    errors?: JsonApiError[] = [];
 
-    constructor(errors ?: Error[]) {
+    constructor(errors ?: JsonApiError[]) {
         if (errors) {
             this.errors = errors;
         }

--- a/src/models/error-response.model.ts
+++ b/src/models/error-response.model.ts
@@ -1,0 +1,23 @@
+export interface Error {
+    id?: string;
+    links ?: Array<any>;
+    status ?: string;
+    code ?: string;
+    title ?: string;
+    detail ?: string;
+    source ?: {
+        pointer ?: string;
+        parameter ?: string
+    };
+    meta ?: any;
+}
+
+export class ErrorResponse {
+    errors?: Error[] = [];
+
+    constructor(errors ?: Error[]) {
+        if (errors) {
+            this.errors = errors;
+        }
+    }
+}

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -159,7 +159,7 @@ export class JsonApiDatastore {
     try {
       let body: any = error.json();
       if (body.errors && body.errors instanceof Array) {
-        let errors = new ErrorResponse(body.errors);
+        let errors: ErrorResponse = new ErrorResponse(body.errors);
         console.error(errMsg, errors);
         return Observable.throw(errors);
       }

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -7,6 +7,7 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
 import { JsonApiModel } from '../models/json-api.model';
+import {ErrorResponse} from '../models/error-response.model';
 
 export type ModelType<T extends JsonApiModel> = { new(datastore: JsonApiDatastore, data: any): T; };
 
@@ -155,6 +156,17 @@ export class JsonApiDatastore {
   protected handleError(error: any): ErrorObservable {
     let errMsg: string = (error.message) ? error.message :
         error.status ? `${error.status} - ${error.statusText}` : 'Server error';
+    try {
+      let body: any = error.json();
+      if (body.errors && body.errors instanceof Array) {
+        let errors = new ErrorResponse(body.errors);
+        console.error(errMsg, errors);
+        return Observable.throw(errors);
+      }
+    } catch (e) {
+      // no valid JSON
+    }
+
     console.error(errMsg);
     return Observable.throw(errMsg);
   }


### PR DESCRIPTION
If a JSON API request returns an error, the server can send error messages [(http://jsonapi.org/format/#errors](url).

This pull request allows users to access such error objects in the `onError` method.
