### PR TITLE
Remove "hard" dependencies to @angular packages and introduce peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,24 +32,27 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "dependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
-    "@angular/http": "2.0.0",
-    "@angular/platform-browser": "2.0.0",
-    "@types/lodash": "^4.14.37",
-    "@types/reflect-metadata": "0.0.4",
-    "core-js": "^2.4.1",
-    "lodash": "^4.16.4",
-    "reflect-metadata": "0.1.3",
-    "rxjs": "5.0.0-beta.12",
-    "zone.js": "0.6.23"
+    "lodash": "^4.16.4"
+  },
+  "peerDependencies": {
+    "@angular/http": "^2.0.0",
+    "@angular/core": "^2.0.0",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "5.0.0-beta.12"
   },
   "devDependencies": {
+    "@angular/core": "^2.0.0",
+    "@angular/common": "^2.0.0",
+    "@angular/compiler": "^2.0.0",
+    "@angular/http": "^2.0.0",
+    "@angular/platform-browser": "^2.0.0",
+    "@angular/platform-browser-dynamic": "^2.0.0",
+    "@types/lodash": "^4.14.37",
+    "@types/reflect-metadata": "0.0.4",
     "@types/jasmine": "^2.2.34",
     "@types/selenium-webdriver": "^2.53.30",
     "@types/es6-shim": "^0.31.32",
-    "@angular/platform-browser-dynamic": "2.0.0",
+    "core-js": "^2.4.1",
     "codelyzer": "^0.0.25",
     "coveralls": "^2.11.14",
     "jasmine-core": "2.4.1",
@@ -62,12 +65,15 @@
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "1.8.0",
     "phantomjs-prebuilt": "2.1.12",
+    "reflect-metadata": "^0.1.3",
     "rimraf": "^2.5.4",
+    "rxjs": "5.0.0-beta.12",
     "sourcemap-istanbul-instrumenter-loader": "^0.2.0",
     "ts-loader": "^0.8.2",
     "tslint": "^3.13.0",
     "typescript": "2.0.2",
-    "webpack": "1.13.2"
+    "webpack": "1.13.2",
+    "zone.js": "0.6.23"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/reflect-metadata": "0.0.4",
     "@types/jasmine": "^2.2.34",
     "@types/selenium-webdriver": "^2.53.30",
-    "@types/es6-shim": "^0.31.32",
     "core-js": "^2.4.1",
     "codelyzer": "^0.0.25",
     "coveralls": "^2.11.14",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,19 @@
     "sourceMap": true,
     "declaration": true,
     "outDir": "./dist",
+    "lib": [
+      "es5",
+      "es2015.iterable",
+      "es2015.collection",
+      "es2015.promise",
+      "dom"
+    ],
     "typeRoots": [
       "node_modules/@types"
     ],
     "types": [
       "jasmine",
       "selenium-webdriver",
-      "es6-shim",
       "lodash",
       "reflect-metadata"
     ]


### PR DESCRIPTION
Include es2015 libs in tsconfig, therefore no typings like es-shim have to be used.
This should fix #46 .
