### PR TITLE
Ability to work with dates as Date objects

### DIFF
--- a/karma.dev.conf.js
+++ b/karma.dev.conf.js
@@ -1,0 +1,50 @@
+"use strict";
+
+var webpackConfig = require('./webpack.test.conf');
+
+module.exports = function (config) {
+  var _config = {
+    basePath: '',
+    frameworks: ['jasmine'],
+
+    plugins: [
+      require('karma-webpack'),
+      require('karma-sourcemap-loader'),
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-spec-reporter'),
+      require('karma-remap-istanbul'),
+      require('karma-coverage')
+    ],
+
+    files: [
+      {pattern: './karma-test-shim.conf.js', watched: false}
+    ],
+
+    preprocessors: {
+      './karma-test-shim.conf.js': ['webpack', 'sourcemap']
+    },
+
+    webpack: webpackConfig,
+
+    webpackServer: {
+      noInfo: true
+    },
+
+    remapIstanbulReporter: {
+      reports: {
+        lcovonly: './coverage/lcov.info',
+        html: './coverage'
+      }
+    },
+
+    reporters: ['spec', 'karma-remap-istanbul'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+  };
+
+  config.set(_config);
+};

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "3.3.0",
   "description": "A lightweight Angular 2 adapter for JSON API",
   "scripts": {
-    "build": "rimraf dist && tsc",
+    "build": "rimraf dist && tslint src/**/*.ts && tsc",
     "lint": "tslint src/**/*.ts",
     "pretest": "npm run build",
     "test": "karma start",
     "prepublish": "tsc",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "servetest": "npm run pretest & karma start karma.dev.conf.js"
   },
   "repository": {
     "type": "git",
@@ -42,21 +43,22 @@
     "rxjs": "5.0.0-beta.12"
   },
   "devDependencies": {
-    "@angular/core": "^2.0.0",
     "@angular/common": "^2.0.0",
     "@angular/compiler": "^2.0.0",
+    "@angular/core": "^2.0.0",
     "@angular/http": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
+    "@types/jasmine": "^2.2.34",
     "@types/lodash": "^4.14.37",
     "@types/reflect-metadata": "0.0.4",
-    "@types/jasmine": "^2.2.34",
     "@types/selenium-webdriver": "^2.53.30",
-    "core-js": "^2.4.1",
     "codelyzer": "^0.0.25",
+    "core-js": "^2.4.1",
     "coveralls": "^2.11.14",
     "jasmine-core": "2.4.1",
     "karma": "1.3.0",
+    "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "1.0.2",
     "karma-phantomjs-launcher": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "dependencies": {
-    "lodash": "^4.16.4"
+    "lodash": "^4.16.4",
+    "moment": "^2.15.2"
   },
   "peerDependencies": {
     "@angular/http": "^2.0.0",

--- a/src/decorators/attribute.decorator.ts
+++ b/src/decorators/attribute.decorator.ts
@@ -4,7 +4,7 @@ import * as moment from 'moment';
 export function Attribute(config: any = {}) {
   return function (target: any, propertyName: string) {
 
-    let converter = function(dataType: any, value: any, forSerialisation: boolean = false): any {
+    let converter = function(dataType: any, value: any, forSerialisation = false): any {
       if (!forSerialisation) {
         if (dataType === Date) {
           return moment.utc(value).toDate();

--- a/src/decorators/attribute.decorator.ts
+++ b/src/decorators/attribute.decorator.ts
@@ -7,7 +7,7 @@ export function Attribute(config: any = {}) {
     let converter = function(dataType: any, value: any, forSerialisation = false): any {
       if (!forSerialisation) {
         if (dataType === Date) {
-          return moment.utc(value).toDate();
+          return moment(value).toDate();
         }
       } else {
         if (dataType === Date) {

--- a/src/decorators/attribute.decorator.ts
+++ b/src/decorators/attribute.decorator.ts
@@ -1,15 +1,33 @@
 import 'reflect-metadata';
+import * as moment from 'moment';
 
 export function Attribute(config: any = {}) {
   return function (target: any, propertyName: string) {
 
+    let converter = function(dataType: any, value: any, forSerialisation: boolean = false): any {
+      if (!forSerialisation) {
+        if (dataType === Date) {
+          return moment.utc(value).toDate();
+        }
+      } else {
+        if (dataType === Date) {
+          return moment(value).format(moment.defaultFormatUtc);
+        }
+      }
+
+      return value;
+    };
+
     let saveAnnotations = function (hasDirtyAttributes: boolean, oldValue: any, newValue: any, isNew: boolean) {
       let annotations = Reflect.getMetadata('Attribute', target) || {};
+      let targetType = Reflect.getMetadata('design:type', target, propertyName);
+
       hasDirtyAttributes = typeof oldValue === 'undefined' && !isNew ? false : hasDirtyAttributes;
       annotations[propertyName] = {
         hasDirtyAttributes: hasDirtyAttributes,
         oldValue: oldValue,
-        newValue: newValue
+        newValue: newValue,
+        serialisationValue: converter(targetType, newValue, true)
       };
       Reflect.defineMetadata('Attribute', annotations, target);
     };
@@ -19,9 +37,11 @@ export function Attribute(config: any = {}) {
     };
 
     let setter = function (newVal: any) {
-      if (newVal !== this['_' + propertyName]) {
+      let targetType = Reflect.getMetadata('design:type', target, propertyName);
+      let convertedValue = converter(targetType, newVal);
+      if (convertedValue !== this['_' + propertyName]) {
         saveAnnotations(true, this['_' + propertyName], newVal, !this.id);
-        this['_' + propertyName] = newVal;
+        this['_' + propertyName] = convertedValue;
       }
     };
 

--- a/src/models/json-api.model.spec.ts
+++ b/src/models/json-api.model.spec.ts
@@ -9,7 +9,7 @@ import { Http, BaseRequestOptions, ConnectionBackend } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 import { Datastore } from '../../test/datastore.service';
 import { Chapter } from '../../test/models/chapter.model';
-
+import * as moment from 'moment';
 
 let datastore: Datastore;
 
@@ -48,7 +48,7 @@ describe('JsonApiModel', () => {
       expect(author).toBeDefined();
       expect(author.id).toBe('1');
       expect(author.name).toBe('Daniele');
-      expect(author.date_of_birth).toBe('1987-05-25');
+      expect(author.date_of_birth.getTime()).toBe(moment('1987-05-25T00:00:00Z').toDate().getTime());
     });
 
     it('should be instanciated without attributes', () => {
@@ -69,10 +69,10 @@ describe('JsonApiModel', () => {
       expect(author).toBeDefined();
       expect(author.id).toBe(AUTHOR_ID);
       expect(author.name).toBe(AUTHOR_NAME);
-      expect(author.date_of_birth).toBe(AUTHOR_BIRTH);
-      expect(author.date_of_death).toBe(AUTHOR_DEATH);
-      expect(author.created_at).toBe(AUTHOR_CREATED);
-      expect(author.updated_at).toBe(AUTHOR_UPDATED);
+      expect(author.date_of_birth.valueOf()).toBe(moment.utc(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
+      expect(author.date_of_death.valueOf()).toBe(moment.utc(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
+      expect(author.created_at.valueOf()).toBe(moment.utc(AUTHOR_CREATED).valueOf());
+      expect(author.updated_at.valueOf()).toBe(moment.utc(AUTHOR_UPDATED).valueOf());
       expect(author.books).toBeUndefined();
     });
 
@@ -86,17 +86,17 @@ describe('JsonApiModel', () => {
         expect(author).toBeDefined();
         expect(author.id).toBe(AUTHOR_ID);
         expect(author.name).toBe(AUTHOR_NAME);
-        expect(author.date_of_birth).toBe(AUTHOR_BIRTH);
-        expect(author.date_of_death).toBe(AUTHOR_DEATH);
-        expect(author.created_at).toBe(AUTHOR_CREATED);
-        expect(author.updated_at).toBe(AUTHOR_UPDATED);
+        expect(author.date_of_birth.valueOf()).toBe(moment.utc(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
+        expect(author.date_of_death.valueOf()).toBe(moment.utc(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
+        expect(author.created_at.valueOf()).toBe(moment.utc(AUTHOR_CREATED).valueOf());
+        expect(author.updated_at.valueOf()).toBe(moment.utc(AUTHOR_UPDATED).valueOf());
         expect(author.books).toBeDefined();
         expect(author.books.length).toBe(BOOK_NUMBER);
         author.books.forEach((book: Book, index: number) => {
           expect(book instanceof Book).toBeTruthy();
           expect(+book.id).toBe(index + 1);
           expect(book.title).toBe(BOOK_TITLE);
-          expect(book.date_published).toBe(BOOK_PUBLISHED);
+          expect(book.date_published.valueOf()).toBe(moment.utc(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
         });
       });
 
@@ -125,17 +125,17 @@ describe('JsonApiModel', () => {
         expect(author).toBeDefined();
         expect(author.id).toBe(AUTHOR_ID);
         expect(author.name).toBe(AUTHOR_NAME);
-        expect(author.date_of_birth).toBe(AUTHOR_BIRTH);
-        expect(author.date_of_death).toBe(AUTHOR_DEATH);
-        expect(author.created_at).toBe(AUTHOR_CREATED);
-        expect(author.updated_at).toBe(AUTHOR_UPDATED);
+        expect(author.date_of_birth.valueOf()).toBe(moment.utc(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
+        expect(author.date_of_death.valueOf()).toBe(moment.utc(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
+        expect(author.created_at.valueOf()).toBe(moment.utc(AUTHOR_CREATED).valueOf());
+        expect(author.updated_at.valueOf()).toBe(moment.utc(AUTHOR_UPDATED).valueOf());
         expect(author.books).toBeDefined();
         expect(author.books.length).toBe(BOOK_NUMBER);
         author.books.forEach((book: Book, index: number) => {
           expect(book instanceof Book).toBeTruthy();
           expect(+book.id).toBe(index + 1);
           expect(book.title).toBe(BOOK_TITLE);
-          expect(book.date_published).toBe(BOOK_PUBLISHED);
+          expect(book.date_published.valueOf()).toBe(moment.utc(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
           expect(book.chapters).toBeDefined();
           expect(book.chapters.length).toBe(CHAPTERS_NUMBER);
           book.chapters.forEach((chapter: Chapter, cindex: number) => {
@@ -145,7 +145,6 @@ describe('JsonApiModel', () => {
           });
         });
       });
-
     });
   });
 });

--- a/src/models/json-api.model.spec.ts
+++ b/src/models/json-api.model.spec.ts
@@ -35,7 +35,7 @@ describe('JsonApiModel', () => {
 
   describe('constructor', () => {
 
-    it('should be instanciated with attributes', () => {
+    it('should be instantiated with attributes', () => {
       const DATA = {
         id: '1',
         attributes: {
@@ -48,10 +48,10 @@ describe('JsonApiModel', () => {
       expect(author).toBeDefined();
       expect(author.id).toBe('1');
       expect(author.name).toBe('Daniele');
-      expect(author.date_of_birth.getTime()).toBe(moment('1987-05-25T00:00:00Z').toDate().getTime());
+      expect(author.date_of_birth.getTime()).toBe(moment('1987-05-25').toDate().getTime());
     });
 
-    it('should be instanciated without attributes', () => {
+    it('should be instantiated without attributes', () => {
       let author: Author = new Author(datastore);
       expect(author).toBeDefined();
       expect(author.id).toBeUndefined();
@@ -69,10 +69,10 @@ describe('JsonApiModel', () => {
       expect(author).toBeDefined();
       expect(author.id).toBe(AUTHOR_ID);
       expect(author.name).toBe(AUTHOR_NAME);
-      expect(author.date_of_birth.valueOf()).toBe(moment.utc(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
-      expect(author.date_of_death.valueOf()).toBe(moment.utc(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
-      expect(author.created_at.valueOf()).toBe(moment.utc(AUTHOR_CREATED).valueOf());
-      expect(author.updated_at.valueOf()).toBe(moment.utc(AUTHOR_UPDATED).valueOf());
+      expect(author.date_of_birth.valueOf()).toBe(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
+      expect(author.date_of_death.valueOf()).toBe(moment(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
+      expect(author.created_at.valueOf()).toBe(moment(AUTHOR_CREATED).valueOf());
+      expect(author.updated_at.valueOf()).toBe(moment(AUTHOR_UPDATED).valueOf());
       expect(author.books).toBeUndefined();
     });
 
@@ -86,17 +86,17 @@ describe('JsonApiModel', () => {
         expect(author).toBeDefined();
         expect(author.id).toBe(AUTHOR_ID);
         expect(author.name).toBe(AUTHOR_NAME);
-        expect(author.date_of_birth.valueOf()).toBe(moment.utc(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
-        expect(author.date_of_death.valueOf()).toBe(moment.utc(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
-        expect(author.created_at.valueOf()).toBe(moment.utc(AUTHOR_CREATED).valueOf());
-        expect(author.updated_at.valueOf()).toBe(moment.utc(AUTHOR_UPDATED).valueOf());
+        expect(author.date_of_birth.valueOf()).toBe(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
+        expect(author.date_of_death.valueOf()).toBe(moment(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
+        expect(author.created_at.valueOf()).toBe(moment(AUTHOR_CREATED).valueOf());
+        expect(author.updated_at.valueOf()).toBe(moment(AUTHOR_UPDATED).valueOf());
         expect(author.books).toBeDefined();
         expect(author.books.length).toBe(BOOK_NUMBER);
         author.books.forEach((book: Book, index: number) => {
           expect(book instanceof Book).toBeTruthy();
           expect(+book.id).toBe(index + 1);
           expect(book.title).toBe(BOOK_TITLE);
-          expect(book.date_published.valueOf()).toBe(moment.utc(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
+          expect(book.date_published.valueOf()).toBe(moment(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
         });
       });
 
@@ -125,17 +125,17 @@ describe('JsonApiModel', () => {
         expect(author).toBeDefined();
         expect(author.id).toBe(AUTHOR_ID);
         expect(author.name).toBe(AUTHOR_NAME);
-        expect(author.date_of_birth.valueOf()).toBe(moment.utc(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
-        expect(author.date_of_death.valueOf()).toBe(moment.utc(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
-        expect(author.created_at.valueOf()).toBe(moment.utc(AUTHOR_CREATED).valueOf());
-        expect(author.updated_at.valueOf()).toBe(moment.utc(AUTHOR_UPDATED).valueOf());
+        expect(author.date_of_birth.valueOf()).toBe(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
+        expect(author.date_of_death.valueOf()).toBe(moment(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
+        expect(author.created_at.valueOf()).toBe(moment(AUTHOR_CREATED).valueOf());
+        expect(author.updated_at.valueOf()).toBe(moment(AUTHOR_UPDATED).valueOf());
         expect(author.books).toBeDefined();
         expect(author.books.length).toBe(BOOK_NUMBER);
         author.books.forEach((book: Book, index: number) => {
           expect(book instanceof Book).toBeTruthy();
           expect(+book.id).toBe(index + 1);
           expect(book.title).toBe(BOOK_TITLE);
-          expect(book.date_published.valueOf()).toBe(moment.utc(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
+          expect(book.date_published.valueOf()).toBe(moment(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
           expect(book.chapters).toBeDefined();
           expect(book.chapters.length).toBe(CHAPTERS_NUMBER);
           book.chapters.forEach((chapter: Chapter, cindex: number) => {

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -70,9 +70,13 @@ export class JsonApiModel {
         if (relationship && relationship.data && relationship.data.length > 0) {
           let typeName: string = relationship.data[0].type;
           let modelType: ModelType<this> = Reflect.getMetadata('JsonApiDatastoreConfig', this._datastore.constructor).models[typeName];
-          let relationshipModel: JsonApiModel[] = this.getHasManyRelationship(modelType, relationship.data, included, typeName, level);
-          if (relationshipModel.length > 0) {
-            this[metadata.propertyName] = relationshipModel;
+          if (modelType) {
+            let relationshipModel: JsonApiModel[] = this.getHasManyRelationship(modelType, relationship.data, included, typeName, level);
+            if (relationshipModel.length > 0) {
+              this[metadata.propertyName] = relationshipModel;
+            }
+          } else {
+            throw {message: 'parseHasMany - Model type for relationship ' + typeName + ' not found.'};
           }
         }
       }
@@ -89,9 +93,13 @@ export class JsonApiModel {
           if (dataRelationship) {
             let typeName: string = dataRelationship.type;
             let modelType: ModelType<this> = Reflect.getMetadata('JsonApiDatastoreConfig', this._datastore.constructor).models[typeName];
-            let relationshipModel: JsonApiModel = this.getBelongsToRelationship(modelType, dataRelationship, included, typeName, level);
-            if (relationshipModel) {
-              this[metadata.propertyName] = relationshipModel;
+            if (modelType) {
+              let relationshipModel: JsonApiModel = this.getBelongsToRelationship(modelType, dataRelationship, included, typeName, level);
+              if (relationshipModel) {
+                this[metadata.propertyName] = relationshipModel;
+              }
+            } else {
+              throw { message: 'parseBelongsTo - Model type for relationship ' + typeName + ' not found.' };
             }
           }
         }

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -30,7 +30,7 @@ export class JsonApiModel {
 
   get hasDirtyAttributes() {
     let attributesMetadata: any = Reflect.getMetadata('Attribute', this);
-    let hasDirtyAttributes: boolean = false;
+    let hasDirtyAttributes = false;
     for (let propertyName in attributesMetadata) {
       if (attributesMetadata.hasOwnProperty(propertyName)) {
         let metadata: any = attributesMetadata[propertyName];
@@ -66,7 +66,7 @@ export class JsonApiModel {
     let hasMany: any = Reflect.getMetadata('HasMany', this);
     if (hasMany) {
       for (let metadata of hasMany) {
-        let relationship: any = data.relationships ? data.relationships[metadata.relationship]: null;
+        let relationship: any = data.relationships ? data.relationships[metadata.relationship] : null;
         if (relationship && relationship.data && relationship.data.length > 0) {
           let typeName: string = relationship.data[0].type;
           let modelType: ModelType<this> = Reflect.getMetadata('JsonApiDatastoreConfig', this._datastore.constructor).models[typeName];
@@ -83,7 +83,7 @@ export class JsonApiModel {
     let belongsTo: any = Reflect.getMetadata('BelongsTo', this);
     if (belongsTo) {
       for (let metadata of belongsTo) {
-        let relationship: any = data.relationships ? data.relationships[metadata.relationship]: null;
+        let relationship: any = data.relationships ? data.relationships[metadata.relationship] : null;
         if (relationship && relationship.data) {
           let dataRelationship: any = (relationship.data instanceof Array) ? relationship.data[0] : relationship.data;
           if (dataRelationship) {

--- a/src/services/json-api-datastore.service.spec.ts
+++ b/src/services/json-api-datastore.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import {MockBackend, MockConnection} from '@angular/http/testing';
 import {Datastore, BASE_URL} from '../../test/datastore.service';
 import {ErrorResponse} from '../models/error-response.model';
+import * as moment from 'moment';
 
 
 let datastore: Datastore;
@@ -50,7 +51,7 @@ describe('JsonApiDatastore', () => {
         it('should build basic url', () => {
             backend.connections.subscribe((c: MockConnection) => {
 
-                expect(c.request.url).toEqual(BASE_URL + "authors");
+                expect(c.request.url).toEqual(BASE_URL + 'authors');
                 expect(c.request.method).toEqual(RequestMethod.Get);
             });
             datastore.query(Author).subscribe();
@@ -58,10 +59,10 @@ describe('JsonApiDatastore', () => {
 
         it('should set JSON API headers', () => {
             backend.connections.subscribe((c: MockConnection) => {
-                expect(c.request.url).toEqual(BASE_URL + "authors");
+                expect(c.request.url).toEqual(BASE_URL + 'authors');
                 expect(c.request.method).toEqual(RequestMethod.Get);
-                expect(c.request.headers.get("Content-Type")).toEqual("application/vnd.api+json");
-                expect(c.request.headers.get("Accept")).toEqual("application/vnd.api+json");
+                expect(c.request.headers.get('Content-Type')).toEqual('application/vnd.api+json');
+                expect(c.request.headers.get('Accept')).toEqual('application/vnd.api+json');
             });
             datastore.query(Author).subscribe();
         });
@@ -69,7 +70,7 @@ describe('JsonApiDatastore', () => {
         it('should build url with params', () => {
             backend.connections.subscribe((c: MockConnection) => {
                 expect(c.request.url).not.toEqual(BASE_URL);
-                expect(c.request.url).toEqual(BASE_URL + "authors?page[size]=10&page[number]=1&include=comments");
+                expect(c.request.url).toEqual(BASE_URL + 'authors?page[size]=10&page[number]=1&include=comments');
                 expect(c.request.method).toEqual(RequestMethod.Get);
             });
             datastore.query(Author, {
@@ -80,24 +81,24 @@ describe('JsonApiDatastore', () => {
 
         it('should have custom headers', () => {
             backend.connections.subscribe((c: MockConnection) => {
-                expect(c.request.url).toEqual(BASE_URL + "authors");
+                expect(c.request.url).toEqual(BASE_URL + 'authors');
                 expect(c.request.method).toEqual(RequestMethod.Get);
-                expect(c.request.headers.has("Authorization")).toBeTruthy();
-                expect(c.request.headers.get("Authorization")).toBe("Bearer");
+                expect(c.request.headers.has('Authorization')).toBeTruthy();
+                expect(c.request.headers.get('Authorization')).toBe('Bearer');
             });
-            datastore.query(Author, null, new Headers({"Authorization": "Bearer"}))
+            datastore.query(Author, null, new Headers({'Authorization': 'Bearer'}))
                 .subscribe();
         });
 
         it('should override base headers', () => {
             backend.connections.subscribe((c: MockConnection) => {
-                expect(c.request.url).toEqual(BASE_URL + "authors");
+                expect(c.request.url).toEqual(BASE_URL + 'authors');
                 expect(c.request.method).toEqual(RequestMethod.Get);
-                expect(c.request.headers.has("Authorization")).toBeTruthy();
-                expect(c.request.headers.get("Authorization")).toBe("Basic");
+                expect(c.request.headers.has('Authorization')).toBeTruthy();
+                expect(c.request.headers.get('Authorization')).toBe('Basic');
             });
-            datastore.headers = new Headers({"Authorization": "Bearer"});
-            datastore.query(Author, null, new Headers({"Authorization": "Basic"}))
+            datastore.headers = new Headers({'Authorization': 'Bearer'});
+            datastore.query(Author, null, new Headers({'Authorization': 'Basic'}))
                 .subscribe();
         });
 
@@ -149,11 +150,9 @@ describe('JsonApiDatastore', () => {
                 },
                 () => fail('onCompleted has been called'));
         });
-
     });
 
     describe('findRecord', () => {
-
         it('should get author', () => {
             backend.connections.subscribe((c: MockConnection) => {
                 c.mockRespond(new Response(
@@ -167,12 +166,8 @@ describe('JsonApiDatastore', () => {
             datastore.findRecord(Author, '1').subscribe((author) => {
                 expect(author).toBeDefined();
                 expect(author.id).toBe(AUTHOR_ID);
-                expect(author.date_of_birth).toEqual(AUTHOR_BIRTH);
+                expect(author.date_of_birth).toEqual(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').toDate());
             });
         });
-
-
     });
-
-
 });

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -116,7 +116,7 @@ export class JsonApiDatastore {
               type: relationshipType,
               id: data[key].id
             }
-          };''
+          };
         }
       }
     }
@@ -178,7 +178,7 @@ export class JsonApiDatastore {
     if (this._headers) {
       this._headers.forEach((values, name) => {
         requestHeaders.set(name, values);
-      })
+      });
     }
 
     if (customHeaders) {
@@ -190,7 +190,7 @@ export class JsonApiDatastore {
   }
 
   private toQueryString(params: any) {
-    let encodedStr: string = '';
+    let encodedStr = '';
     for (let key in params) {
       if (params.hasOwnProperty(key)) {
         if (encodedStr && encodedStr[encodedStr.length - 1] !== '&') {

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -51,7 +51,7 @@ export class JsonApiDatastore {
       if (attributesMetadata.hasOwnProperty(propertyName)) {
         let metadata: any = attributesMetadata[propertyName];
         if (metadata.hasDirtyAttributes) {
-          dirtyData[propertyName] = metadata.newValue;
+          dirtyData[propertyName] = metadata.serialisationValue ? metadata.serialisationValue : metadata.newValue;
         }
       }
     }
@@ -116,7 +116,7 @@ export class JsonApiDatastore {
               type: relationshipType,
               id: data[key].id
             }
-          };
+          };''
         }
       }
     }

--- a/test/fixtures/author.fixture.ts
+++ b/test/fixtures/author.fixture.ts
@@ -2,8 +2,8 @@ export const AUTHOR_ID = '1';
 export const AUTHOR_NAME = 'J. R. R. Tolkien';
 export const AUTHOR_BIRTH = '1892-01-03';
 export const AUTHOR_DEATH = '1973-09-02';
-export const AUTHOR_CREATED = '2016-09-26 21:12:40';
-export const AUTHOR_UPDATED = '2016-09-26 21:12:45';
+export const AUTHOR_CREATED = '2016-09-26T21:12:40Z';
+export const AUTHOR_UPDATED = '2016-09-26T21:12:45Z';
 
 export const BOOK_TITLE = 'The Fellowship of the Ring';
 export const BOOK_PUBLISHED = '1954-07-29';
@@ -48,8 +48,8 @@ export function getIncludedBooks(totalBooks: number, relationship?: string, tota
       'attributes': {
         'date_published': BOOK_PUBLISHED,
         'title': BOOK_TITLE,
-        'created_at': '2016-09-26 21:12:41',
-        'updated_at': '2016-09-26 21:12:41'
+        'created_at': '2016-09-26T21:12:41Z',
+        'updated_at': '2016-09-26T21:12:41Z'
       },
       'relationships': {
         'chapters': {
@@ -91,8 +91,8 @@ export function getIncludedBooks(totalBooks: number, relationship?: string, tota
           'attributes': {
             'title': CHAPTER_TITLE,
             'ordering': chapterId,
-            'created_at': '2016-10-01 12:54:32',
-            'updated_at': '2016-10-01 12:54:32'
+            'created_at': '2016-10-01T12:54:32Z',
+            'updated_at': '2016-10-01T12:54:32Z'
           },
           'relationships': {
             'book': {


### PR DESCRIPTION
I've made a couple of changes, the simple one first.

If parseMany or parseBelongTo fail due to a missing relationship it now gives an appropriate message in the console, rather than the default "Server Error".

I've also added the ability for the attribute decorator to use reflect to get the original property type, reflect.getMetadata('design:type') if the original type was a Date then the value provided is converted to a date object using momentjs.

It should be noted that the following assumptions have been made. The JsonApi spec suggests that ISO8601 format is used for dates, the code assumes the producer of the Api has followed this suggestion. The code also assumes that dates will be sent and received in UTC, this should be a safe assumption for Api providers to multinational clients, or cloud hosting where the timezone of the server cannot be guaranteed.

I have tested these changes against the product we are currently writing and they seem to work ok. Please feel free to ask any questions, or provide improvements.