### PR TITLE
Add method for changing baseUrl

### DIFF
--- a/src/services/json-api-datastore.service.spec.ts
+++ b/src/services/json-api-datastore.service.spec.ts
@@ -50,7 +50,6 @@ describe('JsonApiDatastore', () => {
 
         it('should build basic url', () => {
             backend.connections.subscribe((c: MockConnection) => {
-
                 expect(c.request.url).toEqual(BASE_URL + 'authors');
                 expect(c.request.method).toEqual(RequestMethod.Get);
             });
@@ -168,6 +167,19 @@ describe('JsonApiDatastore', () => {
                 expect(author.id).toBe(AUTHOR_ID);
                 expect(author.date_of_birth).toEqual(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').toDate());
             });
+        });
+    });
+
+    describe('config', () => {
+        it('should change basic url', () => {
+            const customBaseUrl = 'http://custom-test-url.com/';
+
+            datastore.setBaseUrl(customBaseUrl);
+
+            backend.connections.subscribe((c: MockConnection) => {
+                expect(c.request.url).toEqual(customBaseUrl + 'authors');
+            });
+            datastore.query(Author).subscribe();
         });
     });
 });

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -153,7 +153,7 @@ export class JsonApiDatastore {
     return model;
   }
 
-  protected handleError(error: any): ErrorObservable {
+  protected handleError(error: any): ErrorObservable<any> {
     let errMsg: string = (error.message) ? error.message :
         error.status ? `${error.status} - ${error.statusText}` : 'Server error';
     try {
@@ -264,4 +264,7 @@ export class JsonApiDatastore {
     return model;
   };
 
+  public setBaseUrl(baseUrl: string): void {
+    Reflect.getMetadata('JsonApiDatastoreConfig', this.constructor).baseUrl = baseUrl;
+  }
 }


### PR DESCRIPTION
If you have more than one environment, you'll want to set `baseUrl` somehow (probably in the constructor of the datastore service).