### PR TITLE
Optimize lodash usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "typings": "./dist/index.d.ts",
   "dependencies": {
     "@types/qs": "^6.5.0",
-    "lodash": "^4.16.4",
+    "lodash-es": "^4.17.4",
     "moment": "^2.15.2",
     "qs": "^6.5.0"
   },
@@ -54,7 +54,7 @@
     "@angular/platform-browser": "^4.3.3",
     "@angular/platform-server": "^4.3.3",
     "@types/jasmine": "2.5.43",
-    "@types/lodash": "^4.14.71",
+    "@types/lodash-es": "^4.14.6",
     "@types/reflect-metadata": "0.0.5",
     "@types/selenium-webdriver": "^3.0.0",
     "codelyzer": "~3.1.2",

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Headers } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -1,5 +1,6 @@
-import * as _ from 'lodash-es';
 import { Headers } from '@angular/http';
+import extend from 'lodash-es/extend';
+import find from 'lodash-es/find';
 import { Observable } from 'rxjs/Observable';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';
 
@@ -11,7 +12,7 @@ export class JsonApiModel {
   constructor(private _datastore: JsonApiDatastore, data?: any) {
     if (data) {
       this.id = data.id;
-      _.extend(this, data.attributes);
+      extend(this, data.attributes);
     }
   }
 
@@ -109,7 +110,7 @@ export class JsonApiModel {
   private getHasManyRelationship<T extends JsonApiModel>(modelType: ModelType<T>, data: any, included: any, typeName: string, level: number): T[] {
     let relationshipList: T[] = [];
     data.forEach((item: any) => {
-      let relationshipData: any = _.find(included, {id: item.id, type: typeName});
+      let relationshipData: any = find(included, {id: item.id, type: typeName});
       if (relationshipData) {
         let newObject: T = this.createOrPeek(modelType, relationshipData);
         if (level <= 1) {
@@ -124,7 +125,7 @@ export class JsonApiModel {
 
   private getBelongsToRelationship<T extends JsonApiModel>(modelType: ModelType<T>, data: any, included: any, typeName: string, level: number): T {
     let id: string = data.id;
-    let relationshipData: any = _.find(included, {id: id, type: typeName});
+    let relationshipData: any = find(included, {id: id, type: typeName});
     if (relationshipData) {
       let newObject: T = this.createOrPeek(modelType, relationshipData);
       if (level <= 1) {

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {Injectable} from '@angular/core';
 import {Headers, Http, RequestOptions, Response} from '@angular/http';
 import {Observable} from 'rxjs/Observable';

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -1,6 +1,9 @@
-import * as _ from 'lodash-es';
 import {Injectable} from '@angular/core';
 import {Headers, Http, RequestOptions, Response} from '@angular/http';
+import extend from 'lodash-es/extend';
+import find from 'lodash-es/find';
+import keyBy from 'lodash-es/keyBy';
+import objectValues from 'lodash-es/values';
 import {Observable} from 'rxjs/Observable';
 import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
 import 'rxjs/add/operator/map';
@@ -106,7 +109,7 @@ export class JsonApiDatastore {
 
     peekAll<T extends JsonApiModel>(modelType: ModelType<T>): T[] {
         let type = Reflect.getMetadata('JsonApiModelConfig', modelType).type;
-        return _.values(<JsonApiModel>this._store[type]);
+        return objectValues(<JsonApiModel>this._store[type]);
     }
 
     set headers(headers: Headers) {
@@ -183,7 +186,7 @@ export class JsonApiDatastore {
         let body: any = res.json();
         if (model) {
             model.id = body.data.id;
-            _.extend(model, body.data.attributes);
+            extend(model, body.data.attributes);
         }
         model = model || new modelType(this, body.data);
         this.addToStore(model);
@@ -253,12 +256,12 @@ export class JsonApiDatastore {
             this._store[type] = {};
         }
         let hash: any = this.fromArrayToHash(models);
-        _.extend(this._store[type], hash);
+        extend(this._store[type], hash);
     }
 
     private fromArrayToHash(models: JsonApiModel | JsonApiModel[]): any {
         let modelsArray: JsonApiModel[] = models instanceof Array ? models : [models];
-        return _.keyBy(modelsArray, 'id');
+        return keyBy(modelsArray, 'id');
     }
 
     private resetMetadataAttributes<T extends JsonApiModel>(res: any, attributesMetadata: any, modelType: ModelType<T>) {
@@ -281,7 +284,7 @@ export class JsonApiDatastore {
             if (relationships.hasOwnProperty(relationship) && model.hasOwnProperty(relationship)) {
                 let relationshipModel: JsonApiModel = model[relationship];
                 let hasMany: any[] = Reflect.getMetadata('HasMany', relationshipModel);
-                let propertyHasMany: any = _.find(hasMany, (property) => {
+                let propertyHasMany: any = find(hasMany, (property) => {
                     return modelsTypes[property.relationship] === model.constructor;
                 });
                 if (propertyHasMany) {

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -141,9 +141,9 @@ export class JsonApiDatastore {
     }
 
     private isValidToManyRelation(objects: Array<any>): boolean {
-        let isJsonApiModel: boolean = _.every(objects, (item: any) => item instanceof JsonApiModel);
+        let isJsonApiModel = objects.every(item => item instanceof JsonApiModel);
         let relationshipType: string = isJsonApiModel ? Reflect.getMetadata('JsonApiModelConfig', objects[0].constructor).type : '';
-        return isJsonApiModel ? _.every(objects, (item: JsonApiModel) =>
+        return isJsonApiModel ? objects.every((item: JsonApiModel) =>
             Reflect.getMetadata('JsonApiModelConfig', item.constructor).type === relationshipType) : false;
     }
 

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -20,7 +20,7 @@ export type ModelType<T extends JsonApiModel> = { new(datastore: JsonApiDatastor
 export class JsonApiDatastore {
 
     private _headers: Headers;
-    private _store: any = {};
+    private _store: {[type: string]: {[id: string]: JsonApiModel}} = {};
 
     constructor(private http: Http) {
     }
@@ -104,7 +104,7 @@ export class JsonApiDatastore {
 
     peekRecord<T extends JsonApiModel>(modelType: ModelType<T>, id: string): T {
         let type: string = Reflect.getMetadata('JsonApiModelConfig', modelType).type;
-        return this._store[type] ? this._store[type][id] : null;
+        return this._store[type] ? <T>this._store[type][id] : null;
     }
 
     peekAll<T extends JsonApiModel>(modelType: ModelType<T>): T[] {

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -2,7 +2,6 @@ import {Injectable} from '@angular/core';
 import {Headers, Http, RequestOptions, Response} from '@angular/http';
 import extend from 'lodash-es/extend';
 import find from 'lodash-es/find';
-import keyBy from 'lodash-es/keyBy';
 import objectValues from 'lodash-es/values';
 import {Observable} from 'rxjs/Observable';
 import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
@@ -249,19 +248,16 @@ export class JsonApiDatastore {
         return qs.stringify(params, { arrayFormat: 'brackets' });
     }
 
-    public addToStore(models: JsonApiModel | JsonApiModel[]): void {
-        let model: JsonApiModel = models instanceof Array ? models[0] : models;
-        let type: string = Reflect.getMetadata('JsonApiModelConfig', model.constructor).type;
-        if (!this._store[type]) {
-            this._store[type] = {};
+    public addToStore(modelOrModels: JsonApiModel | JsonApiModel[]): void {
+        let models = Array.isArray(modelOrModels) ? modelOrModels : [modelOrModels];
+        let type: string = Reflect.getMetadata('JsonApiModelConfig', models[0].constructor).type;
+        let typeStore = this._store[type];
+        if (!typeStore) {
+            typeStore = this._store[type] = {};
         }
-        let hash: any = this.fromArrayToHash(models);
-        extend(this._store[type], hash);
-    }
-
-    private fromArrayToHash(models: JsonApiModel | JsonApiModel[]): any {
-        let modelsArray: JsonApiModel[] = models instanceof Array ? models : [models];
-        return keyBy(modelsArray, 'id');
+        for (let model of models) {
+            typeStore[model.id] = model;
+        }
     }
 
     private resetMetadataAttributes<T extends JsonApiModel>(res: any, attributesMetadata: any, modelType: ModelType<T>) {


### PR DESCRIPTION
This patch performs the following changes:

* Replaces `_.every()` with `Array.prototype.every()`, an ES5 method
* Replaces `lodash` with `lodash-es`, the official ES6 build (gives Webpack 3 better optimization opportunities with the scope hoisting)
* Includes only the specific functions needed, rather than the entire lodash module — unfortunately, lodash’s design prevents module bundlers from properly eliminating dead code

On my personal project, these changes alone reduced my main bundle by 49 KiB minified (16 KiB gzipped), and lodash now only accounts for 7.4 KiB (down from 24) of the gzipped size.