### PR TITLE
Use ES6 methods when possible

### DIFF
--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -1,5 +1,4 @@
 import { Headers } from '@angular/http';
-import extend from 'lodash-es/extend';
 import find from 'lodash-es/find';
 import { Observable } from 'rxjs/Observable';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';
@@ -12,7 +11,7 @@ export class JsonApiModel {
   constructor(private _datastore: JsonApiDatastore, data?: any) {
     if (data) {
       this.id = data.id;
-      extend(this, data.attributes);
+      Object.assign(this, data.attributes);
     }
   }
 

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -1,6 +1,5 @@
 import {Injectable} from '@angular/core';
 import {Headers, Http, RequestOptions, Response} from '@angular/http';
-import extend from 'lodash-es/extend';
 import find from 'lodash-es/find';
 import objectValues from 'lodash-es/values';
 import {Observable} from 'rxjs/Observable';
@@ -185,7 +184,7 @@ export class JsonApiDatastore {
         let body: any = res.json();
         if (model) {
             model.id = body.data.id;
-            extend(model, body.data.attributes);
+            Object.assign(model, body.data.attributes);
         }
         model = model || new modelType(this, body.data);
         this.addToStore(model);

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
 import {Headers, Http, RequestOptions, Response} from '@angular/http';
 import find from 'lodash-es/find';
-import objectValues from 'lodash-es/values';
 import {Observable} from 'rxjs/Observable';
 import {ErrorObservable} from 'rxjs/observable/ErrorObservable';
 import 'rxjs/add/operator/map';
@@ -107,7 +106,8 @@ export class JsonApiDatastore {
 
     peekAll<T extends JsonApiModel>(modelType: ModelType<T>): T[] {
         let type = Reflect.getMetadata('JsonApiModelConfig', modelType).type;
-        return objectValues(<JsonApiModel>this._store[type]);
+        let typeStore = this._store[type];
+        return typeStore ? Object.keys(typeStore).map(key => <T>typeStore[key]) : [];
     }
 
     set headers(headers: Headers) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,7 @@
     "declaration": true,
     "outDir": "./dist",
     "lib": [
-      "es5",
-      "es2015.iterable",
-      "es2015.collection",
-      "es2015.promise",
+      "es2015",
       "dom"
     ],
     "typeRoots": [


### PR DESCRIPTION
This patch bumps the required library from ES5 to ES2015, and takes advantage of the new methods available.

The methods being used are required by Angular itself (and documented in [Mandatory polyfills](https://angular.io/guide/browser-support#mandatory-polyfills)), so I think this is a safe requirement.
