### PR TITLE
Replace moment.js with date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "typings": "./dist/index.d.ts",
   "dependencies": {
     "@types/qs": "^6.5.0",
+    "date-fns": "^1.28.5",
     "lodash-es": "^4.17.4",
-    "moment": "^2.15.2",
     "qs": "^6.5.0"
   },
   "peerDependencies": {

--- a/src/decorators/attribute.decorator.ts
+++ b/src/decorators/attribute.decorator.ts
@@ -1,4 +1,5 @@
-import * as moment from 'moment';
+import * as dateFormat from 'date-fns/format';
+import * as dateParse from 'date-fns/parse';
 
 export function Attribute(config: any = {}) {
   return function (target: any, propertyName: string) {
@@ -6,11 +7,11 @@ export function Attribute(config: any = {}) {
     let converter = function(dataType: any, value: any, forSerialisation = false): any {
       if (!forSerialisation) {
         if (dataType === Date) {
-          return moment(value).toDate();
+          return dateParse(value);
         }
       } else {
         if (dataType === Date) {
-          return moment(value).format(moment.defaultFormatUtc);
+          return dateFormat(value, 'YYYY-MM-DDTHH:mm:ss[Z]');
         }
       }
 

--- a/src/models/json-api.model.spec.ts
+++ b/src/models/json-api.model.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import * as dateParse from 'date-fns/parse';
 import { Author } from '../../test/models/author.model';
 import {
     AUTHOR_ID, AUTHOR_NAME, AUTHOR_BIRTH, AUTHOR_DEATH,
@@ -9,7 +10,6 @@ import { Http, BaseRequestOptions, ConnectionBackend } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 import { Datastore } from '../../test/datastore.service';
 import { Chapter } from '../../test/models/chapter.model';
-import * as moment from 'moment';
 
 let datastore: Datastore;
 
@@ -48,7 +48,7 @@ describe('JsonApiModel', () => {
       expect(author).toBeDefined();
       expect(author.id).toBe('1');
       expect(author.name).toBe('Daniele');
-      expect(author.date_of_birth.getTime()).toBe(moment('1987-05-25').toDate().getTime());
+      expect(author.date_of_birth.getTime()).toBe(dateParse('1987-05-25').getTime());
     });
 
     it('should be instantiated without attributes', () => {
@@ -69,10 +69,10 @@ describe('JsonApiModel', () => {
       expect(author).toBeDefined();
       expect(author.id).toBe(AUTHOR_ID);
       expect(author.name).toBe(AUTHOR_NAME);
-      expect(author.date_of_birth.valueOf()).toBe(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
-      expect(author.date_of_death.valueOf()).toBe(moment(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
-      expect(author.created_at.valueOf()).toBe(moment(AUTHOR_CREATED).valueOf());
-      expect(author.updated_at.valueOf()).toBe(moment(AUTHOR_UPDATED).valueOf());
+      expect(author.date_of_birth.valueOf()).toBe(dateParse(AUTHOR_BIRTH).valueOf());
+      expect(author.date_of_death.valueOf()).toBe(dateParse(AUTHOR_DEATH).valueOf());
+      expect(author.created_at.valueOf()).toBe(dateParse(AUTHOR_CREATED).valueOf());
+      expect(author.updated_at.valueOf()).toBe(dateParse(AUTHOR_UPDATED).valueOf());
       expect(author.books).toBeUndefined();
     });
 
@@ -86,17 +86,17 @@ describe('JsonApiModel', () => {
         expect(author).toBeDefined();
         expect(author.id).toBe(AUTHOR_ID);
         expect(author.name).toBe(AUTHOR_NAME);
-        expect(author.date_of_birth.valueOf()).toBe(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
-        expect(author.date_of_death.valueOf()).toBe(moment(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
-        expect(author.created_at.valueOf()).toBe(moment(AUTHOR_CREATED).valueOf());
-        expect(author.updated_at.valueOf()).toBe(moment(AUTHOR_UPDATED).valueOf());
+        expect(author.date_of_birth.valueOf()).toBe(dateParse(AUTHOR_BIRTH).valueOf());
+        expect(author.date_of_death.valueOf()).toBe(dateParse(AUTHOR_DEATH).valueOf());
+        expect(author.created_at.valueOf()).toBe(dateParse(AUTHOR_CREATED).valueOf());
+        expect(author.updated_at.valueOf()).toBe(dateParse(AUTHOR_UPDATED).valueOf());
         expect(author.books).toBeDefined();
         expect(author.books.length).toBe(BOOK_NUMBER);
         author.books.forEach((book: Book, index: number) => {
           expect(book instanceof Book).toBeTruthy();
           expect(+book.id).toBe(index + 1);
           expect(book.title).toBe(BOOK_TITLE);
-          expect(book.date_published.valueOf()).toBe(moment(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
+          expect(book.date_published.valueOf()).toBe(dateParse(BOOK_PUBLISHED).valueOf());
         });
       });
 
@@ -125,17 +125,17 @@ describe('JsonApiModel', () => {
         expect(author).toBeDefined();
         expect(author.id).toBe(AUTHOR_ID);
         expect(author.name).toBe(AUTHOR_NAME);
-        expect(author.date_of_birth.valueOf()).toBe(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').valueOf());
-        expect(author.date_of_death.valueOf()).toBe(moment(AUTHOR_DEATH, 'YYYY-MM-DD').valueOf());
-        expect(author.created_at.valueOf()).toBe(moment(AUTHOR_CREATED).valueOf());
-        expect(author.updated_at.valueOf()).toBe(moment(AUTHOR_UPDATED).valueOf());
+        expect(author.date_of_birth.valueOf()).toBe(dateParse(AUTHOR_BIRTH).valueOf());
+        expect(author.date_of_death.valueOf()).toBe(dateParse(AUTHOR_DEATH).valueOf());
+        expect(author.created_at.valueOf()).toBe(dateParse(AUTHOR_CREATED).valueOf());
+        expect(author.updated_at.valueOf()).toBe(dateParse(AUTHOR_UPDATED).valueOf());
         expect(author.books).toBeDefined();
         expect(author.books.length).toBe(BOOK_NUMBER);
         author.books.forEach((book: Book, index: number) => {
           expect(book instanceof Book).toBeTruthy();
           expect(+book.id).toBe(index + 1);
           expect(book.title).toBe(BOOK_TITLE);
-          expect(book.date_published.valueOf()).toBe(moment(BOOK_PUBLISHED, 'YYYY-MM-DD').valueOf());
+          expect(book.date_published.valueOf()).toBe(dateParse(BOOK_PUBLISHED).valueOf());
           expect(book.chapters).toBeDefined();
           expect(book.chapters.length).toBe(CHAPTERS_NUMBER);
           book.chapters.forEach((chapter: Chapter, cindex: number) => {

--- a/src/services/json-api-datastore.service.spec.ts
+++ b/src/services/json-api-datastore.service.spec.ts
@@ -1,4 +1,5 @@
 import {TestBed} from '@angular/core/testing';
+import * as dateParse from 'date-fns/parse';
 import {Author} from '../../test/models/author.model';
 import {AUTHOR_BIRTH, AUTHOR_ID, AUTHOR_NAME, BOOK_TITLE, getAuthorData} from '../../test/fixtures/author.fixture';
 import {
@@ -13,7 +14,6 @@ import {
 import {MockBackend, MockConnection} from '@angular/http/testing';
 import {BASE_URL, Datastore} from '../../test/datastore.service';
 import {ErrorResponse} from '../models/error-response.model';
-import * as moment from 'moment';
 import {getSampleBook} from '../../test/fixtures/book.fixture';
 import {Book} from '../../test/models/book.model';
 
@@ -244,7 +244,7 @@ describe('JsonApiDatastore', () => {
             datastore.findRecord(Author, '1').subscribe((author) => {
                 expect(author).toBeDefined();
                 expect(author.id).toBe(AUTHOR_ID);
-                expect(author.date_of_birth).toEqual(moment(AUTHOR_BIRTH, 'YYYY-MM-DD').toDate());
+                expect(author.date_of_birth).toEqual(dateParse(AUTHOR_BIRTH));
             });
         });
 


### PR DESCRIPTION
Even though angular2-jsonapi only weighs about 3 KiB gzipped, it currently depends on moment.js, which adds about 65 KiB *gzipped* to a project. That absolutely kills the “lightweight” aspect of this library.

A major reason for moment.js being so big is that it bundles all its locales when imported, and getting rid of them requires fiddling with Webpack config (not currently possible with angular-cli). But even if all locales were removed, moment.js core is still 16 KiB gzipped, more than five times the size of this library’s core. We can do better!

This patch replaces moment with [date-fns](https://date-fns.org), a highly modular date library that allows us to import just the components we need, with minimal overhead. These are the numbers I got on my project:

&nbsp;    | minified  | min+gzip
----------|----------:|---------:
moment.js | 305.8 KiB | 65.5 KiB
date-fns  |   8.6 KiB | **2.9 KiB**

(By the way, this patch *preserves* a serialization bug, as fixing it might break those who are already relying on it. I will make a different pull request for that)
