### PR TITLE
Fix timezone in serialized dates

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -445,8 +445,8 @@ export class Post extends JsonApiModel {
 ```
 
 Moreover, it should be noted that the following assumptions have been made:
-- The JsonApi spec suggests that ISO8601 format is used for dates, the code assumes the producer of the Api has followed this suggestion
-- The library also assumes that dates will be sent and received in UTC. This should be a safe assumption for Api providers to multinational clients, or cloud hosting where the timezone of the server cannot be guaranteed.
+- Dates are expected to be received in one of the ISO 8601 formats, as per the [JSON API spec recommendation](http://jsonapi.org/recommendations/#date-and-time-fields);
+- Dates are always sent in full ISO 8601 format, with local timezone and without milliseconds (example: `2001-02-03T14:05:06+07:00`).
 
 
 ## TODO

--- a/src/decorators/attribute.decorator.ts
+++ b/src/decorators/attribute.decorator.ts
@@ -11,7 +11,7 @@ export function Attribute(config: any = {}) {
         }
       } else {
         if (dataType === Date) {
-          return dateFormat(value, 'YYYY-MM-DDTHH:mm:ss[Z]');
+          return dateFormat(value, 'YYYY-MM-DDTHH:mm:ssZ');
         }
       }
 


### PR DESCRIPTION
The current implementation of `Date` serialization sends the current local date with a hardcoded "Z" prefix, completely discarding timezone information.

## Example

For example, let’s say the user is located at UTC-4, and they choose 10 am Aug 24 on some timepicker. This is what this library currently sends to the server: `2017-08-24T10:00:00Z`.

If the backend is written in, say, Node.js, calling `getHours()` would return 6 rather than the expected 10. To work around this, it must either use a `getUTCHours()` call, or discard the “Z” suffix and assume the time is local (but then they don’t know the client’s timezone and can’t convert it to actual UTC if needed).

With this patch, the frontend will instead send: `2017-08-24T10:00:00-04:00`. The backend is then free to choose between working with local time or UTC, as both will return the expected values.

## Breaking change

However, it's possible there are servers already designed around the current behavior, so this means this fix is technically a **breaking change**. I'd recommend holding it off until a planned 4.0 release.