### PR TITLE
Support for multiple types per HasMany field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
     },
     "@types/qs": {
       "version": "https://registry.npmjs.org/@types/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha1-FFFOjuJKTQZywMDaXgGk8R2mDXE="
+      "integrity": "sha512-KCvdV85GNkZAyWOYxUUR+3XNairGv60Niu42GvVy9JlXRPEIZHXQuk0xMi/mla/25pLZzdY7uzLhBK/B81KZBg=="
     },
     "@types/reflect-metadata": {
       "version": "https://registry.npmjs.org/@types/reflect-metadata/-/reflect-metadata-0.0.5.tgz",
@@ -2233,7 +2233,7 @@
     },
     "karma-chrome-launcher": {
       "version": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
-      "integrity": "sha1-zxudBxNswY/iOTJ9JGVMPbw2is8=",
+      "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
         "fs-access": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
@@ -4210,7 +4210,7 @@
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"


### PR DESCRIPTION
Currently, we only get one type of models per HasMany field but if there are more than one type they are not being checked. 

**For example**

-- entity:
----relationships: 
--------components:
------------Type: A 
------------Type: B

Whichever comes first in relationships array gets loaded by the library (in this case Type:A), not the second type (in this case Type:B)

Another loop is added in **parseHasMany** function of **json-api.model.ts**. And it also tracks typeName not to loop over again by the same type in order to avoid duplicate entries.

