### PR TITLE
Fix #105 - createOrPeek update local data if record already exists

### DIFF
--- a/src/models/json-api.model.spec.ts
+++ b/src/models/json-api.model.spec.ts
@@ -130,6 +130,28 @@ describe('JsonApiModel', () => {
           });
         });
       });
+
+      describe('update relationships', () => {
+        it ('should return updated relationship', () => {
+          const REL = 'books';
+          const BOOK_NUMBER = 1;
+          const CHAPTERS_NUMBER = 4;
+          const DATA = getAuthorData(REL, BOOK_NUMBER);
+          const INCLUDED = getIncludedBooks(BOOK_NUMBER);
+          const NEW_BOOK_TITLE = 'The Hobbit'
+          author = new Author(datastore, DATA);
+          author.syncRelationships(DATA, INCLUDED, 0);
+          INCLUDED.forEach(model => {
+            if (model.type === 'books') {
+              model.attributes.title = NEW_BOOK_TITLE;
+            }
+          })
+          author.syncRelationships(DATA, INCLUDED, 0);
+          author.books.forEach(book => {
+            expect(book.title).toBe(NEW_BOOK_TITLE);
+          });
+        });
+      });
     });
   });
 });

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -3,6 +3,7 @@ import find from 'lodash-es/find';
 import { Observable } from 'rxjs/Observable';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';
 import { ModelConfig } from '../interfaces/model-config.interface';
+import * as _ from 'lodash';
 
 export class JsonApiModel {
   id: string;
@@ -142,6 +143,7 @@ export class JsonApiModel {
   private createOrPeek<T extends JsonApiModel>(modelType: ModelType<T>, data: any): T {
     let peek = this._datastore.peekRecord(modelType, data.id);
     if (peek) {
+      _.extend(peek, data.attributes);
       return peek;
     }
     let newObject: T = new modelType(this._datastore, data);


### PR DESCRIPTION
Fix #015

Now when a model of a relationship exists in a peek store it will be update the attributes.