### PR TITLE
Fix error handling when saving records in JsonApiDatastore

### DIFF
--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -126,10 +126,6 @@ export class JsonApiDatastore {
 
     return httpCall
       .map((res) => res.status === 201 ? this.extractRecordData(res, modelType, model) : model)
-      .catch((error) => {
-        console.error(error);
-        return Observable.of(model);
-      })
       .map((res) => this.resetMetadataAttributes(res, attributesMetadata, modelType))
       .map((res) => this.updateRelationships(res, relationships))
       .catch((res) => this.handleError(res));


### PR DESCRIPTION
After creating a record with `this.datastore.createRecord(Example, {})` and using `save().subscribe((example: Example) => { console.log(example); })`, it is not possible to catch an error if the HTTP response has an error status code (e.g. "400 Bad Request") because `saveRecord` returns an `Observable` of the model.

It would be better to use the default `handleError` method of `JsonApiDatastore` if an error occurs when saving a record.