### PR TITLE
fixing example for findAll usage

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -186,7 +186,7 @@ getPosts(){
     this.datastore.findAll(Post, {
         page: { size: 10, number: 1}
     }).subscribe(
-        (posts: Post[]) => console.log(posts)
+        (posts: JsonApiQueryData<Post>) => console.log(posts.getModels())
     );
 }
 ```


### PR DESCRIPTION
Currently the readme shows incorrect usage of the response signature for `findAll`.  This fixes the example implementation