### PR TITLE
patching attribute with oldValue as undefined

### DIFF
--- a/src/decorators/attribute.decorator.ts
+++ b/src/decorators/attribute.decorator.ts
@@ -57,7 +57,7 @@ export function Attribute(options: AttributeDecoratorOptions = {}): PropertyDeco
         instance[AttributeMetadata] = {};
       }
 
-      const propertyHasDirtyAttributes = typeof oldValue === 'undefined' && !isNew ? false : hasDirtyAttributes;
+      const propertyHasDirtyAttributes = (oldValue === newValue) ? false : hasDirtyAttributes;
 
       instance[AttributeMetadata][propertyName] = {
         newValue,


### PR DESCRIPTION
Below line in the attribute decorate makes it impossible to patch an attribute that may have come as `undefined` from the server. New value was never taken into consideration

`const propertyHasDirtyAttributes = typeof oldValue === 'undefined' && !isNew ? false : hasDirtyAttributes;`

