### PR TITLE
setup @angular lib in peer dependencies to use `npm link` for local testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
     "qs": "^6.5.1"
   },
   "peerDependencies": {
+    "@angular/animations": "^4.4.3",
+    "@angular/common": "^4.4.3",
+    "@angular/compiler": "^4.4.3",
+    "@angular/compiler-cli": "^4.4.3",
+    "@angular/core": "^4.4.3",
+    "@angular/platform-browser": "^4.4.3",
+    "@angular/platform-browser-dynamic": "^4.4.3",
+    "@angular/platform-server": "^4.4.3",
     "reflect-metadata": ">=0.1.3",
     "rxjs": ">=5.2.0"
   },


### PR DESCRIPTION
I was getting errors about differences in `HttpClient` while trying to test using a linked version of this library locally.   According to this document: https://github.com/angular/angular-cli/wiki/stories-linked-library all `@angular` dependencies need to be added as peer dependencies. After setting this up and building the library, i can successfully run `ng serve --watch` to get live updates while testing. 