### PR TITLE
simple accessor to get meta data passed into models

### DIFF
--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -7,17 +7,25 @@ import * as _ from 'lodash';
 import { AttributeMetadata } from '../constants/symbols';
 
 export class JsonApiModel {
-  id: string;
-  meta: any;
   [key: string]: any;
 
   // tslint:disable-next-line:variable-name
-  constructor(private _datastore: JsonApiDatastore, data?: any) {
+  constructor(private _datastore: JsonApiDatastore, protected data?: any) {
     if (data) {
-      this.id = data.id;
-      this.meta = data.meta;
       Object.assign(this, data.attributes);
     }
+  }
+
+  get id(): string {
+    return this.data.id;
+  }
+
+  get meta(): any {
+    return this.data.meta;
+  }
+
+  get relationships(): any {
+    return this.data.relationships;
   }
 
   syncRelationships(data: any, included: any, level: number): void {

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -7,17 +7,15 @@ import * as _ from 'lodash';
 import { AttributeMetadata } from '../constants/symbols';
 
 export class JsonApiModel {
+  id: string;
   [key: string]: any;
 
   // tslint:disable-next-line:variable-name
   constructor(private _datastore: JsonApiDatastore, protected data?: any) {
     if (data) {
+      this.id = data.id;
       Object.assign(this, data.attributes);
     }
-  }
-
-  get id(): string {
-    return this.data.id;
   }
 
   get meta(): any {

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -8,12 +8,14 @@ import { AttributeMetadata } from '../constants/symbols';
 
 export class JsonApiModel {
   id: string;
+  meta: any;
   [key: string]: any;
 
   // tslint:disable-next-line:variable-name
   constructor(private _datastore: JsonApiDatastore, data?: any) {
     if (data) {
       this.id = data.id;
+      this.meta = data.meta;
       Object.assign(this, data.attributes);
     }
   }


### PR DESCRIPTION
Fixes issue #155 by adding the meta data for a model accessible without any  requirement of adding that meta data to the datastore.  