### PR TITLE
update a locally stored object with serialized attribute names

### DIFF
--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -194,7 +194,7 @@ export class JsonApiModel {
     const peek = this._datastore.peekRecord(modelType, data.id);
 
     if (peek) {
-      _.extend(peek, data.attributes);
+      _.extend(peek, this._datastore.transformSerializedNamesToPropertyNames(modelType, data.attributes));
       return peek;
     }
 

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -438,7 +438,7 @@ export class JsonApiDatastore {
     return Object.assign(configFromDecorator, this.config);
   }
 
-  protected transformSerializedNamesToPropertyNames<T extends JsonApiModel>(modelType: ModelType<T>, attributes: any) {
+  public transformSerializedNamesToPropertyNames<T extends JsonApiModel>(modelType: ModelType<T>, attributes: any) {
     const serializedNameToPropertyName = this.getModelPropertyNames(modelType.prototype);
     const properties: any = {};
 


### PR DESCRIPTION
fixes #183 

it might be worth considering moving `transformSerializedNamesToPropertyNames` into the model class. For now i needed to make that method public so the model can access it.