### PR TITLE
FIX: rollbackAttributes from private to public

### DIFF
--- a/src/converters/json-model/json-model.converter.spec.ts
+++ b/src/converters/json-model/json-model.converter.spec.ts
@@ -43,7 +43,7 @@ describe('JsonModel converter', () => {
         const VALUE = null;
         expect(() => {
           converter.mask(VALUE);
-        }).toThrow(new Error('ERROR: JsonModelConverter: Expected array but got ' + typeof VALUE + '.'));
+        }).toThrow(new Error(`ERROR: JsonModelConverter: Expected array but got ${typeof VALUE}.`));
       });
     });
 

--- a/src/converters/json-model/json-model.converter.ts
+++ b/src/converters/json-model/json-model.converter.ts
@@ -26,7 +26,7 @@ export class JsonModelConverter<T> implements PropertyConverter {
     let result = null;
     if (this.options.hasMany) {
       if (!Array.isArray(value)) {
-        throw new Error('ERROR: JsonModelConverter: Expected array but got ' + typeof value + '.');
+        throw new Error(`ERROR: JsonModelConverter: Expected array but got ${typeof value}.`);
       }
       result = [];
       for (const item of value) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export * from './decorators/json-attribute.decorator';
 export * from './decorators/json-api-model-config.decorator';
 export * from './decorators/json-api-datastore-config.decorator';
 
-
 export * from './models/json-api-meta.model';
 export * from './models/json-api.model';
 export * from './models/json-nested.model';
@@ -21,7 +20,6 @@ export * from './interfaces/datastore-config.interface';
 export * from './interfaces/model-config.interface';
 export * from './interfaces/attribute-decorator-options.interface';
 export * from './interfaces/property-converter.interface';
-
 
 export * from './providers';
 

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -98,7 +98,7 @@ export class JsonApiModel {
     }
   }
 
-  private rollbackAttributes(): void {
+  public rollbackAttributes(): void {
     const attributesMetadata: any = this[AttributeMetadataIndex];
     for (const propertyName in attributesMetadata) {
       if (attributesMetadata.hasOwnProperty(propertyName)) {

--- a/src/services/json-api-datastore.service.spec.ts
+++ b/src/services/json-api-datastore.service.spec.ts
@@ -8,13 +8,13 @@ import { API_VERSION, BASE_URL, Datastore } from '../../test/datastore.service';
 import { ErrorResponse } from '../models/error-response.model';
 import { getSampleBook } from '../../test/fixtures/book.fixture';
 import { Book } from '../../test/models/book.model';
-import { ModelConfig } from '../index';
+import { JsonApiQueryData, ModelConfig } from '../index';
 import {
   API_VERSION_FROM_CONFIG,
   BASE_URL_FROM_CONFIG,
   DatastoreWithConfig
 } from '../../test/datastore-with-config.service';
-import { HttpHeaders, HttpErrorResponse } from '@angular/common/http';
+import { HttpHeaders } from '@angular/common/http';
 
 let datastore: Datastore;
 let datastoreWithConfig: DatastoreWithConfig;
@@ -52,7 +52,7 @@ describe('JsonApiDatastore', () => {
       const authorModelConfig: ModelConfig = Reflect.getMetadata('JsonApiModelConfig', Author);
       const expectedUrl = `${BASE_URL}/${API_VERSION}/${authorModelConfig.type}`;
 
-      datastore.query(Author).subscribe();
+      datastore.findAll(Author).subscribe();
 
       const queryRequest = httpMock.expectOne({ method: 'GET', url: expectedUrl });
       queryRequest.flush({ data: [] });
@@ -62,7 +62,7 @@ describe('JsonApiDatastore', () => {
       const authorModelConfig: ModelConfig = Reflect.getMetadata('JsonApiModelConfig', Author);
       const expectedUrl = `${BASE_URL_FROM_CONFIG}/${API_VERSION_FROM_CONFIG}/${authorModelConfig.type}`;
 
-      datastoreWithConfig.query(Author).subscribe();
+      datastoreWithConfig.findAll(Author).subscribe();
 
       const queryRequest = httpMock.expectOne({ method: 'GET', url: expectedUrl });
       queryRequest.flush({ data: [] });
@@ -73,7 +73,7 @@ describe('JsonApiDatastore', () => {
       const authorModelConfig: ModelConfig = Reflect.getMetadata('JsonApiModelConfig', CustomAuthor);
       const expectedUrl = `${BASE_URL_FROM_CONFIG}/${AUTHOR_API_VERSION}/${AUTHOR_MODEL_ENDPOINT_URL}`;
 
-      datastoreWithConfig.query(CustomAuthor).subscribe();
+      datastoreWithConfig.findAll(CustomAuthor).subscribe();
 
       const queryRequest = httpMock.expectOne({ method: 'GET', url: expectedUrl });
       queryRequest.flush({ data: [] });
@@ -82,7 +82,7 @@ describe('JsonApiDatastore', () => {
     it('should set JSON API headers', () => {
       const expectedUrl = `${BASE_URL}/${API_VERSION}/authors`;
 
-      datastore.query(Author).subscribe();
+      datastore.findAll(Author).subscribe();
 
       const queryRequest = httpMock.expectOne({ method: 'GET', url: expectedUrl });
       expect(queryRequest.request.headers.get('Content-Type')).toEqual('application/vnd.api+json');
@@ -110,7 +110,7 @@ describe('JsonApiDatastore', () => {
         encodeURIComponent('include') + '=comments&' +
         encodeURIComponent('filter[title][keyword]') + '=Tolkien';
 
-      datastore.query(Author, queryData).subscribe();
+      datastore.findAll(Author, queryData).subscribe();
 
       httpMock.expectNone(`${BASE_URL}/${API_VERSION}`);
       const queryRequest = httpMock.expectOne({ method: 'GET', url: expectedUrl });
@@ -120,7 +120,7 @@ describe('JsonApiDatastore', () => {
     it('should have custom headers', () => {
       const expectedUrl = `${BASE_URL}/${API_VERSION}/authors`;
 
-      datastore.query(Author, null, new HttpHeaders({ Authorization: 'Bearer' })).subscribe();
+      datastore.findAll(Author, null, new HttpHeaders({ Authorization: 'Bearer' })).subscribe();
 
       const queryRequest = httpMock.expectOne({ method: 'GET', url: expectedUrl });
       expect(queryRequest.request.headers.get('Authorization')).toEqual('Bearer');
@@ -131,7 +131,7 @@ describe('JsonApiDatastore', () => {
       const expectedUrl = `${BASE_URL}/${API_VERSION}/authors`;
 
       datastore.headers = new HttpHeaders({ Authorization: 'Bearer' });
-      datastore.query(Author, null, new HttpHeaders({ Authorization: 'Basic' })).subscribe();
+      datastore.findAll(Author, null, new HttpHeaders({ Authorization: 'Basic' })).subscribe();
 
       const queryRequest = httpMock.expectOne({ method: 'GET', url: expectedUrl });
       expect(queryRequest.request.headers.get('Authorization')).toEqual('Basic');
@@ -141,7 +141,8 @@ describe('JsonApiDatastore', () => {
     it('should get authors', () => {
       const expectedUrl = `${BASE_URL}/${API_VERSION}/authors`;
 
-      datastore.query(Author).subscribe((authors) => {
+      datastore.findAll(Author).subscribe((data: JsonApiQueryData<Author>) => {
+        const authors = data.getModels();
         expect(authors).toBeDefined();
         expect(authors.length).toEqual(1);
         expect(authors[0].id).toEqual(AUTHOR_ID);
@@ -204,7 +205,7 @@ describe('JsonApiDatastore', () => {
         ]
       };
 
-      datastore.query(Author).subscribe(
+      datastore.findAll(Author).subscribe(
         (authors) => fail('onNext has been called'),
         (response) => {
           expect(response).toEqual(jasmine.any(ErrorResponse));
@@ -234,7 +235,7 @@ describe('JsonApiDatastore', () => {
       const expectedQueryString = 'arrayParam[]=4&arrayParam[]=5&arrayParam[]=6';
       const expectedUrl = encodeURI(`${BASE_URL}/${API_VERSION}/books?${expectedQueryString}`);
 
-      datastore.query(Book, { arrayParam: [4, 5, 6] }).subscribe();
+      datastore.findAll(Book, { arrayParam: [4, 5, 6] }).subscribe();
 
       const queryRequest = httpMock.expectOne(expectedUrl);
       queryRequest.flush({ data: [] });


### PR DESCRIPTION
FIX: Consecutive blank lines are forbidden
FIX: TSLint: Use a template literal instead of concatenating with a string literal. (prefer-template)
FIX: failing tests in json-api-datastore.service.spec.ts and json-model.converter.spec.ts