### PR TITLE
Bug including resource in multiple resources

### DIFF
--- a/src/models/json-api.model.spec.ts
+++ b/src/models/json-api.model.spec.ts
@@ -143,6 +143,17 @@ describe('JsonApiModel', () => {
 
       });
 
+      it('should parse relationships included in more than one resource', () => {
+        const BOOK_NUMBER = 4;
+        const DATA = getAuthorData('books.category', BOOK_NUMBER);
+        author = new Author(datastore, DATA);
+        author.syncRelationships(DATA, getIncludedBooks(BOOK_NUMBER));
+        author.books.forEach((book: Book, index: number) => {
+          expect(book.category).toBeDefined();
+          expect(book.category.books.length).toBe(BOOK_NUMBER);
+        });
+      });
+
       it('should return the parsed relationships when two nested ones are included', () => {
         const REL = 'books,books.chapters';
         const BOOK_NUMBER = 2;

--- a/src/models/json-api.model.spec.ts
+++ b/src/models/json-api.model.spec.ts
@@ -145,10 +145,11 @@ describe('JsonApiModel', () => {
 
       it('should parse relationships included in more than one resource', () => {
         const BOOK_NUMBER = 4;
-        const DATA = getAuthorData('books.category.books', BOOK_NUMBER);
+        const REL = 'books.category.books';
+        const DATA = getAuthorData(REL, BOOK_NUMBER);
         author = new Author(datastore, DATA);
-        author.syncRelationships(DATA, getIncludedBooks(BOOK_NUMBER));
-        author.books.forEach((book: Book, index: number) => {
+        author.syncRelationships(DATA, getIncludedBooks(BOOK_NUMBER, REL));
+        author.books.forEach((book: Book) => {
           expect(book.category).toBeDefined();
           expect(book.category.books.length).toBe(BOOK_NUMBER);
         });

--- a/src/models/json-api.model.spec.ts
+++ b/src/models/json-api.model.spec.ts
@@ -145,7 +145,7 @@ describe('JsonApiModel', () => {
 
       it('should parse relationships included in more than one resource', () => {
         const BOOK_NUMBER = 4;
-        const DATA = getAuthorData('books.category', BOOK_NUMBER);
+        const DATA = getAuthorData('books.category.books', BOOK_NUMBER);
         author = new Author(datastore, DATA);
         author.syncRelationships(DATA, getIncludedBooks(BOOK_NUMBER));
         author.books.forEach((book: Book, index: number) => {

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -45,7 +45,7 @@ export class JsonApiModel {
     if (data) {
       let modelsForProcessing = remainingModels;
 
-      if (!modelsForProcessing) {
+      if (modelsForProcessing === undefined) {
         modelsForProcessing = [].concat(included);
       }
 
@@ -202,16 +202,18 @@ export class JsonApiModel {
     const relationshipList: Array<T> = [];
 
     data.forEach((item: any) => {
-      const relationshipData: any = find(remainingModels, { id: item.id, type: typeName } as any);
+      const relationshipData: any = find(included, { id: item.id, type: typeName } as any);
 
       if (relationshipData) {
         const newObject: T = this.createOrPeek(modelType, relationshipData);
 
         const indexOfNewlyFoundModel = remainingModels.indexOf(relationshipData);
         const modelsForProcessing = remainingModels.concat([]);
-        modelsForProcessing.splice(indexOfNewlyFoundModel, 1);
 
-        newObject.syncRelationships(relationshipData, included, modelsForProcessing);
+        if (indexOfNewlyFoundModel !== -1) {
+          modelsForProcessing.splice(indexOfNewlyFoundModel, 1);
+          newObject.syncRelationships(relationshipData, included, modelsForProcessing);
+        }
 
         relationshipList.push(newObject);
       }
@@ -229,16 +231,18 @@ export class JsonApiModel {
   ): T | null {
     const id: string = data.id;
 
-    const relationshipData: any = find(remainingModels, { id, type: typeName } as any);
+    const relationshipData: any = find(included, { id, type: typeName } as any);
 
     if (relationshipData) {
       const newObject: T = this.createOrPeek(modelType, relationshipData);
 
       const indexOfNewlyFoundModel = remainingModels.indexOf(relationshipData);
       const modelsForProcessing = remainingModels.concat([]);
-      modelsForProcessing.splice(indexOfNewlyFoundModel, 1);
 
-      newObject.syncRelationships(relationshipData, included, modelsForProcessing);
+      if (indexOfNewlyFoundModel !== -1) {
+        modelsForProcessing.splice(indexOfNewlyFoundModel, 1);
+        newObject.syncRelationships(relationshipData, included, modelsForProcessing);
+      }
 
       return newObject;
     }

--- a/test/datastore.service.ts
+++ b/test/datastore.service.ts
@@ -7,6 +7,7 @@ import { Chapter } from './models/chapter.model';
 import { Section } from './models/section.model';
 import { Paragraph } from './models/paragraph.model';
 import { Sentence } from './models/sentence.model';
+import { Category } from './models/category.model';
 
 export const BASE_URL = 'http://localhost:8080';
 export const API_VERSION = 'v1';
@@ -18,6 +19,7 @@ export const API_VERSION = 'v1';
     authors: Author,
     books: Book,
     chapters: Chapter,
+    categories: Category,
     paragraphs: Paragraph,
     sections: Section,
     sentences: Sentence,

--- a/test/fixtures/author.fixture.ts
+++ b/test/fixtures/author.fixture.ts
@@ -3,6 +3,7 @@ import { getSampleChapter } from './chapter.fixture';
 import { getSampleSection } from './section.fixture';
 import { getSampleParagraph } from './paragraph.fixture';
 import { getSampleSentence } from './sentence.fixture';
+import { getSampleCategory } from './category.fixture';
 
 export const AUTHOR_ID = '1';
 export const AUTHOR_NAME = 'J. R. R. Tolkien';
@@ -13,6 +14,8 @@ export const AUTHOR_UPDATED = '2016-09-26T21:12:45Z';
 
 export const BOOK_TITLE = 'The Fellowship of the Ring';
 export const BOOK_PUBLISHED = '1954-07-29';
+
+export const CATEGORY_ID = '1';
 
 export const CHAPTER_TITLE = 'The Return Journey';
 
@@ -59,7 +62,7 @@ export function getIncludedBooks(totalBooks: number, relationship?: string, tota
   let chapterId = 0;
 
   for (let i = 1; i <= totalBooks; i++) {
-    const book: any = getSampleBook(i, AUTHOR_ID);
+    const book: any = getSampleBook(i, AUTHOR_ID, CATEGORY_ID);
     responseArray.push(book);
 
     if (relationship && relationship.indexOf('books.chapters') !== -1) {
@@ -75,6 +78,23 @@ export function getIncludedBooks(totalBooks: number, relationship?: string, tota
 
         responseArray.push(chapter);
       }
+    }
+
+    if (relationship && relationship.indexOf('books.category') !== -1) {
+      let categoryInclude = responseArray.find((category) => {
+        return category.type === 'categories' && category.id === CATEGORY_ID;
+      });
+
+      if (!categoryInclude) {
+        categoryInclude = getSampleCategory(CATEGORY_ID);
+        categoryInclude.relationships.books = { data: [] };
+        responseArray.push(categoryInclude);
+      }
+
+      categoryInclude.relationships.books.data.push({
+        id: `${i}`,
+        type: 'books'
+      });
     }
 
     if (relationship && relationship.indexOf('books.firstChapter') !== -1) {

--- a/test/fixtures/book.fixture.ts
+++ b/test/fixtures/book.fixture.ts
@@ -1,6 +1,6 @@
 import { BOOK_PUBLISHED, BOOK_TITLE } from './author.fixture';
 
-export function getSampleBook(i: number, authorId: string) {
+export function getSampleBook(i: number, authorId: string, categoryId: string = '1') {
   return {
     id: '' + i,
     type: 'books',
@@ -31,6 +31,16 @@ export function getSampleBook(i: number, authorId: string) {
         data: {
           id: authorId,
           type: 'authors'
+        }
+      },
+      category: {
+        links: {
+          self: '/v1/books/1/relationships/category',
+          related: '/v1/books/1/category'
+        },
+        data: {
+          id: categoryId,
+          type: 'categories'
         }
       }
     },

--- a/test/fixtures/category.fixture.ts
+++ b/test/fixtures/category.fixture.ts
@@ -1,0 +1,16 @@
+export function getSampleCategory(categoryId: string) {
+  return {
+    id: '' + categoryId,
+    type: 'categories',
+    attributes: {
+      name: 'Category_fiction',
+      created_at: '2018-04-02T21:12:41Z',
+      updated_at: '2016-04-02T21:12:41Z'
+    },
+    relationships: {
+    },
+    links: {
+      self: '/v1/categories/1'
+    }
+  };
+}

--- a/test/models/book.model.ts
+++ b/test/models/book.model.ts
@@ -1,5 +1,6 @@
 import { Chapter } from './chapter.model';
 import { Author } from './author.model';
+import { Category } from './category.model';
 import { JsonApiModelConfig } from '../../src/decorators/json-api-model-config.decorator';
 import { JsonApiModel } from '../../src/models/json-api.model';
 import { Attribute } from '../../src/decorators/attribute.decorator';
@@ -31,4 +32,7 @@ export class Book extends JsonApiModel {
 
   @BelongsTo()
   author: Author;
+
+  @BelongsTo()
+  category: Category;
 }

--- a/test/models/category.model.ts
+++ b/test/models/category.model.ts
@@ -1,0 +1,23 @@
+import { Book } from './book.model';
+import { JsonApiModelConfig } from '../../src/decorators/json-api-model-config.decorator';
+import { JsonApiModel } from '../../src/models/json-api.model';
+import { Attribute } from '../../src/decorators/attribute.decorator';
+import { HasMany } from '../../src/decorators/has-many.decorator';
+
+@JsonApiModelConfig({
+  type: 'categories'
+})
+export class Category extends JsonApiModel {
+
+  @Attribute()
+  name: string;
+
+  @Attribute()
+  created_at: Date;
+
+  @Attribute()
+  updated_at: Date;
+
+  @HasMany()
+  books: Book[];
+}


### PR DESCRIPTION
When a certain resource is included in the response and is a relation for multiple resources, it is only included in the angular2-jsonapi models once.

To explain I've created a test that fails on the current master branch, and is resolved in my fix.
I've added a category entity, which represents the category of a book.
If I request an author, with include=books.category.books, the following is happens:
- author.books is correctly set
- author.books.category is correctly set
- **author.books.category.books is undefined**

This is caused by methods getBelongsToRelationship and getHasManyRelationship. They look for the relationship in the remainingModels array where they should be looking in the included array.