### PR TITLE
Allow mixed types with same modelEndpointUrl in HasMany relationship

### DIFF
--- a/src/services/json-api-datastore.service.spec.ts
+++ b/src/services/json-api-datastore.service.spec.ts
@@ -487,7 +487,7 @@ describe('JsonApiDatastore', () => {
       saveRequest.flush({});
     });
 
-    it('should not update invalid mixed ToMany relationships of author', () => {
+    it('should not update invalid mixed HasMany relationship of author', () => {
       const expectedUrl = `${BASE_URL}/${API_VERSION}/authors/${AUTHOR_ID}`;
       const author = new Author(datastore, {
         id: AUTHOR_ID,
@@ -520,7 +520,7 @@ describe('JsonApiDatastore', () => {
       crimeBook.modelConfig.modelEndpointUrl = originalModelEndpointUrl;
     });
 
-    it('should update valid mixed ToMany relationships of author', () => {
+    it('should update valid mixed HasMany relationship of author', () => {
       const expectedUrl = `${BASE_URL}/${API_VERSION}/authors/${AUTHOR_ID}`;
       const author = new Author(datastore, {
         id: AUTHOR_ID,
@@ -549,6 +549,7 @@ describe('JsonApiDatastore', () => {
 
       saveRequest.flush({});
     });
+
     it('should update author with 204 response', () => {
       const expectedUrl = `${BASE_URL}/${API_VERSION}/authors/${AUTHOR_ID}`;
       const author = new Author(datastore, {

--- a/src/services/json-api-datastore.service.spec.ts
+++ b/src/services/json-api-datastore.service.spec.ts
@@ -526,7 +526,8 @@ describe('JsonApiDatastore', () => {
         id: AUTHOR_ID,
         attributes: {
           date_of_birth: parse(AUTHOR_BIRTH),
-          name: AUTHOR_NAME
+          name: AUTHOR_NAME,
+          firstNames: ['John', 'Ronald', 'Reuel']
         }
       });
 

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -246,9 +246,13 @@ export class JsonApiDatastore {
 
   protected isValidToManyRelation(objects: Array<any>): boolean {
     const isJsonApiModel = objects.every((item) => item instanceof JsonApiModel);
-    const relationshipType: string = isJsonApiModel ? objects[0].modelConfig.type : '';
-
-    return isJsonApiModel ? objects.every((item: JsonApiModel) => item.modelConfig.type === relationshipType) : false;
+    if (!isJsonApiModel) {
+      return false;
+    }
+    const types = objects.map((item: JsonApiModel) => item.modelConfig.modelEndpointUrl || item.modelConfig.type);
+    return types
+      .filter((type: string, index: number, self: string[]) => self.indexOf(type) === index)
+      .length === 1;
   }
 
   protected buildSingleRelationshipData(model: JsonApiModel): any {

--- a/test/models/author.model.ts
+++ b/test/models/author.model.ts
@@ -27,6 +27,9 @@ export class Author extends JsonApiModel {
   @Attribute()
   updated_at: Date;
 
+  @Attribute()
+  firstNames: string[];
+
   @HasMany()
   books: Book[];
 

--- a/test/models/crime-book.model.ts
+++ b/test/models/crime-book.model.ts
@@ -1,0 +1,13 @@
+import { Attribute } from '../../src/decorators/attribute.decorator';
+import { JsonApiModelConfig } from '../../src/decorators/json-api-model-config.decorator';
+import { Book } from './book.model';
+
+@JsonApiModelConfig({
+  type: 'crimeBooks',
+  modelEndpointUrl: 'books'
+})
+export class CrimeBook extends Book {
+
+  @Attribute()
+  ageLimit: number;
+}


### PR DESCRIPTION
- Check `modelEndpointUrl` first to check validity of `HasMany` relation
- Add test data (`CrimeBook`) that extends `Book` to test the new functionality