### PR TITLE
Allow removal of HasMany relations by setting empty array

### DIFF
--- a/src/services/json-api-datastore.service.spec.ts
+++ b/src/services/json-api-datastore.service.spec.ts
@@ -548,5 +548,27 @@ describe('JsonApiDatastore', () => {
         }
       });
     });
+
+    it('should remove empty ToMany-relationships', () => {
+      const expectedUrl = `${BASE_URL}/${API_VERSION}/authors/${AUTHOR_ID}`;
+      const BOOK_NUMBER = 2;
+      const DATA = getAuthorData('books', BOOK_NUMBER);
+      const author = new Author(datastore, DATA);
+
+      author.books = [];
+
+      author.save().subscribe();
+
+      httpMock.expectNone(`${BASE_URL}/${API_VERSION}/authors`);
+      const saveRequest = httpMock.expectOne({ method: 'PATCH', url: expectedUrl });
+      const obj = saveRequest.request.body.data;
+      expect(obj.relationships).toBeDefined();
+      expect(obj.relationships.books).toBeDefined();
+      expect(obj.relationships.books.data).toBeDefined();
+      expect(obj.relationships.books.data.length).toBe(0);
+
+      saveRequest.flush({});
+
+    });
   });
 });

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -217,7 +217,7 @@ export class JsonApiDatastore {
   protected getRelationships(data: any): any {
     let relationships: any;
 
-    const toManyRelationships: any[] = Reflect.getMetadata('HasMany', data) || [];
+    const hasManyMetadata: any[] = Reflect.getMetadata('HasMany', data) || [];
 
     for (const key in data) {
       if (data.hasOwnProperty(key)) {
@@ -229,18 +229,19 @@ export class JsonApiDatastore {
               data: this.buildSingleRelationshipData(data[key])
             };
           }
-        } else if (data[key] instanceof Array
-          && this.isToManyRelationship(key, toManyRelationships)
-          && this.containsValidToManyRelations(data[key])
-        ) {
-          relationships = relationships || {};
-          const relationshipData = data[key]
-            .filter((model: JsonApiModel) => model.id)
-            .map((model: JsonApiModel) => this.buildSingleRelationshipData(model));
+        } else if (data[key] instanceof Array) {
+          const entity = hasManyMetadata.find((entity: any) => entity.propertyName === key);
+          if (entity && this.isValidToManyRelation(data[key])) {
+            relationships = relationships || {};
 
-          relationships[key] = {
-            data: relationshipData
-          };
+            const relationshipData = data[key]
+              .filter((model: JsonApiModel) => model.id)
+              .map((model: JsonApiModel) => this.buildSingleRelationshipData(model));
+
+            relationships[key] = {
+              data: relationshipData
+            };
+          }
         }
       }
     }
@@ -248,11 +249,7 @@ export class JsonApiDatastore {
     return relationships;
   }
 
-  protected isToManyRelationship(key: string, toManyRelationships: any[]): boolean {
-    return !!toManyRelationships.find((property: any) => property.propertyName === key);
-  }
-
-  protected containsValidToManyRelations(objects: Array<any>): boolean {
+  protected isValidToManyRelation(objects: Array<any>): boolean {
     if (!objects.length) {
       return true;
     }


### PR DESCRIPTION
The problem with BelongsTo relationships described in issue #146 also exists for ToMany-relationships.

I changed the logic to allow empty arrays as relationships and send the correct request to the server.
See added testcase for details.
