### PR TITLE
expose relationship links

### DIFF
--- a/projects/angular2-jsonapi/src/models/json-api.model.ts
+++ b/projects/angular2-jsonapi/src/models/json-api.model.ts
@@ -16,9 +16,23 @@ import { HttpHeaders } from '@angular/common/http';
 // tslint:disable-next-line:variable-name
 const AttributeMetadataIndex: string = AttributeMetadata as any;
 
+const parseRelationshipLinks = relationships => {
+  const result = {};
+  const linksMapper = ({ links }, key) => {
+    if (links) {
+      result[key] = { links };
+    }
+  };
+
+  _.forEach(relationships || {}, linksMapper);
+
+  return result;
+};
+
 export class JsonApiModel {
   id: string;
   public modelInitialization = false;
+  public relationshipLinks = {};
 
   [key: string]: any;
 
@@ -28,6 +42,7 @@ export class JsonApiModel {
     if (data) {
       this.modelInitialization = true;
       this.id = data.id;
+      this.relationshipLinks = parseRelationshipLinks(data.relationships);
       Object.assign(this, data.attributes);
       this.modelInitialization = false;
     }


### PR DESCRIPTION
In some cases, there are too many relations and we need to paginate them.

Also, we would like to utilize nested routes (`chats/1/messages` instead of `messages?filter[chat]=1`). 

Dunno is it related to ghidoz/angular2-jsonapi#103

Can we just expose the relationship links? Because it feels natural to receive them from the backend.

Then we could do something like this:

```typescript
export class DatastoreService extends JsonApiDatastore {
  constructor(http: HttpClient) {
    super(http);

    this.headers = new HttpHeaders({
      accept: 'application/vnd.api+json',
      'content-type': 'application/vnd.api+json',
      'x-auth-token': getSomeToken(),
    });
  }

  getRelationPageOrSomthingBetterNamed(
    model: ModelType<JsonApiModel>,
    url: string
  ) {
    return this.findAll(
        model,
        {},
        this.getOptions().headers,
        url
      );
  }
}

const messageObservable = this.datastore.getRelationPageOrSomthingBetterNamed(
  Message,
  chat.relationshipLinks.messages.links.next // http://localhost:7000/api/v1/chats/1/messages?page[number]=2
);
```