### PR TITLE
set model based on its type

### DIFF
--- a/projects/angular2-jsonapi/src/services/json-api-datastore.service.ts
+++ b/projects/angular2-jsonapi/src/services/json-api-datastore.service.ts
@@ -331,7 +331,7 @@ export class JsonApiDatastore {
     const models: T[] = [];
 
     body.data.forEach((data: any) => {
-      const model: T = this.deserializeModel(modelType, data);
+      const model: T = this.deserializeModel(this.datastoreConfig.models[data.type], data);
       this.addToStore(model);
 
       if (body.included) {


### PR DESCRIPTION
In some cases, it is suitable to have subtypes of the model.

For example, the Author and Consumer both extend User. So `/users` endpoint serves heterogeneous types.