### PR TITLE
Fix build warning during UMD bundling

### DIFF
--- a/projects/angular2-jsonapi/ng-package.json
+++ b/projects/angular2-jsonapi/ng-package.json
@@ -2,7 +2,13 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/angular2-jsonapi",
   "lib": {
-    "entryFile": "src/public-api.ts"
+    "entryFile": "src/public-api.ts",
+    "umdModuleIds": {
+      "date-fns": "date-fns",
+      "lodash": "lodash",
+      "lodash-es": "lodash-es",
+      "qs": "qs"
+    }
   },
   "whitelistedNonPeerDependencies": [
     "date-fns",

--- a/projects/angular2-jsonapi/src/models/json-api.model.ts
+++ b/projects/angular2-jsonapi/src/models/json-api.model.ts
@@ -1,5 +1,4 @@
-import find from 'lodash-es/find';
-import includes from 'lodash-es/includes';
+import { find, includes } from 'lodash-es';
 import { Observable } from 'rxjs';
 import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.service';
 import { ModelConfig } from '../interfaces/model-config.interface';

--- a/projects/angular2-jsonapi/src/services/json-api-datastore.service.ts
+++ b/projects/angular2-jsonapi/src/services/json-api-datastore.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
-import find from 'lodash-es/find';
+import { find } from 'lodash-es';
 import { catchError, map } from 'rxjs/operators';
 import { Observable, of, throwError } from 'rxjs';
 import { JsonApiModel } from '../models/json-api.model';


### PR DESCRIPTION
Fixes #262. Add external dependencies to `ng-package.json` to remove warnings during build process. Further change import of lodash-es methods to import only from lodash-es. This will also most likely fix the warning reported in #261.